### PR TITLE
Word literal overflow falls afoul of GHC warnings

### DIFF
--- a/src/Reopt/Relinker.hs
+++ b/src/Reopt/Relinker.hs
@@ -93,7 +93,7 @@ writeBS mv base bs = do
 write32_lsb :: SMV.MVector s Word8 -> Word64 -> Word32 -> ST s ()
 write32_lsb v a c = do
   -- Assert there are at least
-  assert (a <= -4) $ do
+  assert (a <= maxBound-3) $ do
   let i = fromIntegral a
   SMV.write v i     $ fromIntegral c
   SMV.write v (i+1) $ fromIntegral (c `shiftR`  8)


### PR DESCRIPTION
@joehendrix  The code here failed to compile due to warnings on `-4 :: Word32` and `-Werror`.  I'm not clear on the intent as it seems odd - could you confirm that whatever is going on was actually intended prior to merge?