### PR TITLE
Replace deprecated GitHub Actions functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         repository: GaloisInc/vadd-CVC4
         ref: eqrange-quant
     - name: Export CVC_HASH
-      run: echo "::set-env name=CVC4_HASH::`git rev-parse HEAD`"
+      run: echo "CVC4_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
     - name: Cache CVC4
       id: cache-cvc4
       uses: actions/cache@v1
@@ -56,8 +56,8 @@ jobs:
     - name: Get GHC
       run: |
         sudo apt-get install --no-install-recommends -y cabal-install-3.0 ghc-${{ matrix.ghc-ver }}
-        echo "::add-path::/opt/cabal/bin"
-        echo "::add-path::/opt/ghc/${{ matrix.ghc-ver }}/bin"
+        echo "/opt/cabal/bin" >> $GITHUB_PATH
+        echo "/opt/ghc/${{ matrix.ghc-ver }}/bin" >> $GITHUB_PATH
     - name: Cache
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
`add-path` and `set-env` have been deprecated as of 10/1/2020 and will be removed, this patch replaces them with environment files to keep the existing workflows running.