### PR TITLE
feat: reopt stats reporting/exporting

### DIFF
--- a/reopt-explore/Main_explore.hs
+++ b/reopt-explore/Main_explore.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main (main) where
+
+import Control.Monad (when, foldM)
+import Control.Exception (catch, SomeException)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Macaw.Discovery ( DiscoveryOptions(..) )
+import Data.Macaw.X86 ( X86_64 )
+import Data.List ( intercalate )
+import Data.Maybe ( isNothing )
+import Data.Version ( Version(versionBranch) )
+import Numeric.Natural ( Natural )
+import Paths_reopt (version)
+import Reopt
+    ( LoadOptions(LoadOptions, loadOffset),
+      ReoptOptions(ReoptOptions, roIncluded, roExcluded),
+      copyrightNotice,
+      RecoveryStats(..),
+      withElfFilesInDir,
+      statsHeader,
+      recoverFunctions,
+      renderFnStats,
+      renderLLVMBitcode,
+      defaultLLVMGenOptions,
+      latestLLVMConfig,
+      statsRows,
+      RecoveredModule,
+      X86OS)
+import System.Console.CmdArgs.Explicit
+    ( process, flagNone, flagReq, mode, Arg(..), Flag, Mode )
+import System.Environment (getArgs)
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+import Text.Printf (printf)
+
+reoptVersion :: String
+reoptVersion = "Reopt binary explorer (reopt-explore) "  ++ versionString ++ "."
+  where [h,l,r] = versionBranch version
+        versionString = show h ++ "." ++ show l ++ "." ++ show r
+
+
+-- | Command line arguments.
+data Args
+   = Args { programPaths  :: ![FilePath]
+            -- ^ Path to input program to optimize/export
+          , clangPath :: !FilePath
+            -- ^ Path to `clang` command.
+            --
+            -- This is only used as a C preprocessor for parsing
+            -- header files.
+          , printStats :: !Bool
+            -- ^ Should we print discovery/recovery statistics to stdout?
+          , exportStatsPath :: !(Maybe FilePath)
+            -- ^ Should we export discovery/recovery statistics?
+          }
+
+defaultArgs :: Args
+defaultArgs =
+  Args
+  { programPaths  = []
+  , clangPath = "clang"
+  , printStats = False
+  , exportStatsPath = Nothing
+  }
+
+-- | Flag to set clang path.
+clangPathFlag :: Flag Args
+clangPathFlag =
+  let upd s old = Right $ old {clangPath = s}
+      help = printf "Path to clang (default "++(clangPath defaultArgs)++")"
+  in flagReq [ "clang" ] upd "PATH" help
+
+statsPrintFlag :: Flag Args
+statsPrintFlag = flagNone [ "print-stats" ] upd help
+  where upd old = old { printStats = True}
+        help = "Print discovery/recovery statistics."
+
+statsExportFlag :: Flag Args
+statsExportFlag = flagReq [ "export-stats" ] upd "PATH" help
+  where upd path old = Right $ old { exportStatsPath = Just path }
+        help = "Path at which to write discovery/recovery statistics."
+
+-- | Flag to set the path to the binary to analyze.
+filenameArg :: Arg Args
+filenameArg = Arg { argValue = addFilename
+                  , argType = "FILE"
+                  , argRequire = False
+                  }
+  where addFilename :: String -> Args -> Either String Args
+        addFilename nm a = Right (a { programPaths = nm:(programPaths a) })
+
+
+arguments :: Mode Args
+arguments = mode "reopt-explore" defaultArgs help filenameArg flags
+  where help = reoptVersion ++ "\n" ++ copyrightNotice
+        flags = [ clangPathFlag
+                , statsPrintFlag
+                , statsExportFlag
+                ]
+
+getCommandLineArgs :: IO Args
+getCommandLineArgs = do
+  argStrings <- getArgs
+  case process arguments argStrings of
+    Left msg -> do
+      hPutStrLn stderr msg
+      exitFailure
+    Right v -> return v
+
+data LLVMGenResult
+  = LLVMGenFail String -- ^ Error message
+  | LLVMGenPass Natural -- ^ How many bytes of LLVM bitcode were generated.
+
+llvmGenSuccess :: LLVMGenResult -> Bool
+llvmGenSuccess LLVMGenPass{} = True
+llvmGenSuccess LLVMGenFail{} = False
+
+data ExplorationResult
+  = ExplorationStats RecoveryStats LLVMGenResult
+  | ExplorationError FilePath String
+
+renderExplorationResult :: ExplorationResult -> String
+renderExplorationResult =
+  \case
+    ExplorationStats stats (LLVMGenPass n)  ->
+      "\n"++ renderFnStats stats ++ "\n"++(show n)++" bytes of LLVM bitcode generated."
+    ExplorationStats stats (LLVMGenFail errMsg)  ->
+      "\n"++ renderFnStats stats ++ "\nLLVM bitcode generation failed:\n" ++ (indentErrMsg errMsg)
+    ExplorationError fpath errMsg ->
+      "\nreopt encountered a fatal error while exploring the binary " ++ fpath ++ ":\n" ++ (indentErrMsg errMsg)
+  where
+    indentErrMsg :: String -> String
+    indentErrMsg msg = "  " ++ concatMap (\c -> if c == '\n' then "\n  " else [c]) msg
+
+
+exploreBinary ::
+  Args ->
+  [ExplorationResult] ->
+  FilePath ->
+  IO [ExplorationResult]
+exploreBinary args results fPath = do
+  hPutStrLn stderr $ "Analyzing binary " ++ fPath ++ " ..."
+  result <- catch performRecovery
+                  (handleFailure ExplorationError)
+  pure $ result:results
+  where
+    lOpts = LoadOptions { loadOffset = Nothing }
+    dOpts = DiscoveryOptions
+            { exploreFunctionSymbols = False
+            , exploreCodeAddrInMem   = False
+            , logAtAnalyzeFunction   = True
+            , logAtAnalyzeBlock      = False
+            }
+    rOpts = ReoptOptions { roIncluded = []
+                          , roExcluded = []
+                          }
+    hdrPath = Nothing
+    unnamedFunPrefix = BSC.pack "reopt"
+    performRecovery :: IO ExplorationResult
+    performRecovery = do
+        (os, recMod, stats) <- recoverFunctions fPath
+                                                (clangPath args)
+                                                lOpts
+                                                dOpts
+                                                rOpts
+                                                hdrPath
+                                                unnamedFunPrefix
+        hPutStrLn stderr $ "Completed analyzing binary " ++ fPath ++ "."
+        catch (do sz <- generateLLVM os recMod; pure $ ExplorationStats stats $ LLVMGenPass sz)
+              (handleFailure $ \_ errMsg -> ExplorationStats stats $ LLVMGenFail errMsg)
+    -- | Generate LLVM bitcode and return the number of bytes generated.
+    generateLLVM :: X86OS -> RecoveredModule X86_64 -> IO Natural
+    generateLLVM os recMod = do
+        hPutStrLn stderr $ "Generating LLVM bitcode..."
+        let (llvm, _) = renderLLVMBitcode defaultLLVMGenOptions
+                                          latestLLVMConfig
+                                          os
+                                          recMod
+        let sz = BSL.length $ BS.toLazyByteString llvm
+        hPutStrLn stderr $ (show sz) ++ " bytes of LLVM bitcode generated."
+        pure $ if sz < 0 then 0 else fromIntegral sz
+    handleFailure :: (FilePath -> String -> ExplorationResult) -> SomeException -> IO ExplorationResult
+    handleFailure mkResult e = do
+        hPutStrLn stderr "Error raised during exploration"
+        hPutStrLn stderr $ show e
+        pure $ mkResult fPath (show e)
+
+
+data SummaryStats =
+  SummaryStats
+  { totalBinaryCount :: Natural
+  -- ^ Which binary are these statistics for?
+  , totalFnDiscoveredCount :: Natural
+  -- ^ Number of discovered functions.
+  , totalFnRecoveredCount :: Natural
+  -- ^ Number of successfully recovered functions.
+  , totalFnPLTSkippedCount :: Natural
+  -- ^ Number of skipped PLT stubs.
+  , totalFnFailedCount :: Natural
+  -- ^ Number of functions which failed during recovery.
+  , totalErrorCount :: Natural
+  -- ^ Overall number of errors encountered while exploring binaries.
+  , totalFailedBinaries :: Natural
+  -- ^ Number of binaries which failed to complete discovery.
+  , totalLLVMGenerated :: Natural
+  -- ^ Number of binaries which we successfully produced LLVM bitcode for.
+  }
+
+initSummaryStats :: SummaryStats
+initSummaryStats = SummaryStats 0 0 0 0 0 0 0 0
+
+renderSummaryStats :: [ExplorationResult] -> String
+renderSummaryStats results = formatSummary $ foldr processResult initSummaryStats results
+  where
+    processResult :: ExplorationResult -> SummaryStats -> SummaryStats
+    processResult (ExplorationStats s llvmGenRes) acc =
+      acc { totalBinaryCount = 1 + (totalBinaryCount acc)
+          , totalFnDiscoveredCount = (statsFnDiscoveredCount s) + (totalFnDiscoveredCount acc)
+          , totalFnRecoveredCount = (statsFnRecoveredCount s) + (totalFnRecoveredCount acc)
+          , totalFnPLTSkippedCount = (statsFnPLTSkippedCount s) + (totalFnPLTSkippedCount acc)
+          , totalFnFailedCount = (statsFnFailedCount s) + (totalFnFailedCount acc)
+          , totalErrorCount = (statsErrorCount s) + (totalErrorCount acc)
+          , totalLLVMGenerated = (totalLLVMGenerated acc) + (if llvmGenSuccess llvmGenRes then 1 else 0)
+          }
+    processResult (ExplorationError _ _) acc =
+      acc { totalBinaryCount = 1 + (totalBinaryCount acc)
+          , totalFailedBinaries = 1 + (totalFailedBinaries acc)
+          }
+    formatSummary :: SummaryStats -> String
+    formatSummary s =
+      if (totalFnDiscoveredCount s) == 0
+      then "\nreopt discovered no functions after exploring "++(show $ totalBinaryCount s)++" binaries."
+      else
+        let passed :: Double = (fromIntegral $ totalFnRecoveredCount s) / (fromIntegral $  totalFnDiscoveredCount s)
+            passedStr = printf " (%.2f%%)" (passed * 100.0)
+            failed :: Double = (fromIntegral $ totalFnFailedCount s) / (fromIntegral $  totalFnDiscoveredCount s)
+            failedStr = printf " (%.2f%%)" (failed * 100.0)
+            skipped :: Double = (fromIntegral $ totalFnPLTSkippedCount s) / (fromIntegral $  totalFnDiscoveredCount s)
+            skippedStr = printf " (%.2f%%)" (skipped * 100.0)
+        in "\nrepot generated LLVM bitcode for "++(show $ totalLLVMGenerated s)++" out of "++(show $ totalBinaryCount s)++" binaries."++
+           "\nreopt discovered " ++ (show (totalFnDiscoveredCount s)) ++ " functions while exploring "++(show $ totalBinaryCount s)++" binaries:" ++
+           "\n  recovery succeeded: " ++ (show (totalFnDiscoveredCount s)) ++ passedStr ++
+           "\n     recovery failed: " ++ (show (totalFnFailedCount s)) ++ failedStr ++
+           "\n    skipped PLT stub: " ++ (show (totalFnPLTSkippedCount s)) ++ skippedStr ++
+           "\n"++(show $ totalErrorCount s)++" errors occurred during exploration."
+
+
+
+
+
+main :: IO ()
+main = do
+  args <- getCommandLineArgs
+  case programPaths args of
+    [] -> do
+      hPutStrLn stderr "Must provide at least one input program or directory to explore."
+      exitFailure
+    paths -> do
+      when ((not $ printStats args) && isNothing (exportStatsPath args)) $ do
+        hPutStrLn stderr "There is nothing to be done."
+        hPutStrLn stderr "Please provide either the --print-stats and/or --export-stats=PATH flag(s)."
+        exitFailure
+      results <- foldM (withElfFilesInDir (exploreBinary args)) [] paths
+      when (printStats args) $ do
+        hPutStrLn stderr "\n==== reopt-explore individual statistics ===="
+        mapM_ (\s -> hPutStrLn stderr (renderExplorationResult s)) results
+        hPutStrLn stderr "\n==== reopt-explore cumulative statistics ===="
+        hPutStrLn stderr $ renderSummaryStats results
+      case exportStatsPath args of
+        Nothing -> pure ()
+        Just exportPath -> do
+          let hdrStr = intercalate "," statsHeader
+              rowsStr = map (intercalate ",") $ concatMap toRows results
+          writeFile exportPath $ unlines $ hdrStr:rowsStr
+          hPutStrLn stderr $ "CSV-formatted statistics written to " ++ exportPath
+  where
+    toRows :: ExplorationResult -> [[String]]
+    toRows (ExplorationStats stats _) = statsRows stats
+    toRows (ExplorationError _ _) = [[]]
+
+
+

--- a/reopt.cabal
+++ b/reopt.cabal
@@ -22,7 +22,9 @@ library
     aeson,
     bytestring,
     containers,
+    directory,
     elf-edit >= 0.40,
+    filepath,
     flexdis86 >= 0.1.1,
     hashable,
     language-c,
@@ -83,6 +85,7 @@ executable reopt
     aeson,
     bytestring >= 0.10.8.0,
     containers,
+    directory,
     cmdargs,
     elf-edit,
     filepath,
@@ -103,6 +106,29 @@ executable reopt
   if flag(enable-hpc)
     ghc-options: -fhpc
 
+  ghc-prof-options: -O2 -fprof-auto-top
+
+executable reopt-explore
+  default-language: Haskell2010
+  build-depends:
+    base >= 4,
+    bytestring,
+    cmdargs,
+    elf-edit,
+    lens,
+    macaw-base,
+    macaw-x86,
+    mtl,
+    reopt
+
+  hs-source-dirs: reopt-explore
+  main-is: Main_explore.hs
+  other-modules: Paths_reopt
+
+  if flag(enable-hpc)
+    ghc-options: -fhpc
+
+  ghc-options: -Wall
   ghc-prof-options: -O2 -fprof-auto-top
 
 executable reopt-relink

--- a/tests/ReoptTests.hs
+++ b/tests/ReoptTests.hs
@@ -17,7 +17,6 @@ import           System.IO
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
 
-import qualified Reopt.CFG.LLVM as LLVM
 import qualified Reopt.CFG.LLVM.X86 as LLVM
 import           Reopt
 
@@ -27,10 +26,6 @@ reoptTests = T.testGroup "reopt" . map mkTest
 -- | Function that accepts warnings/errors from macaw.
 logger :: RecoveryLogEvent -> IO ()
 logger _msg = pure () -- error $ "Test failed: " ++ msg
-
-defaultLLVMGenOptions :: LLVM.LLVMGenOptions
-defaultLLVMGenOptions =
-  LLVM.LLVMGenOptions { LLVM.mcExceptionIsUB = False }
 
 -- | This just tests that we can successfully run discovery,
 -- function recovery and LLVM generation on the given input Elf file.

--- a/tests/ReoptTests.hs
+++ b/tests/ReoptTests.hs
@@ -25,7 +25,7 @@ reoptTests :: [FilePath] -> T.TestTree
 reoptTests = T.testGroup "reopt" . map mkTest
 
 -- | Function that accepts warnings/errors from macaw.
-logger :: GetFnsLogEvent -> IO ()
+logger :: RecoveryLogEvent -> IO ()
 logger _msg = pure () -- error $ "Test failed: " ++ msg
 
 defaultLLVMGenOptions :: LLVM.LLVMGenOptions


### PR DESCRIPTION
Adds the following recovery statistics flags to `reopt`:
```
     --print-stats               Print discovery/recovery statistics.

     --export-stats=PATH         Path at which to write discovery/recovery
                                 statistics.
```

E.g., `reopt --print-stats fib_test.1234` will run reopt through discovery/recovery and then emit a summary (i.e., starting with "reopt discovered ...") after completing:
```
$ reopt --print-stats fib_test.1234
...
reopt discovered 1086 functions:
  recovery succeeded: 287 (26.43%)
     recovery failed: 799 (73.57%)
    skipped PLT stub: 0 (0.00%)
800 errors occured.
```

whereas using the `--export-stats=PATH` flag will output the recovery statistics info a CSV file named `PATH` with a header in the first line and data entries on the remaining lines, e.g.:
```
binary,fn name,address,recovery result
fib_test.1234,,0x400270,FnFailedRecovery
fib_test.1234,,0x400276,FnFailedRecovery
fib_test.1234,_IO_default_seekpos,0x40dff0,FnFailedRecovery
fib_test.1234,_IO_default_setbuf,0x40ded0,FnFailedRecovery
fib_test.1234,_IO_default_showmanyc,0x40ed10,FnRecovered
fib_test.1234,_IO_default_stat,0x40ece0,FnRecovered
fib_test.1234,_IO_default_sync,0x40e350,FnRecovered
...
```

The [statistics](https://github.com/GaloisInc/reopt/blob/abd456341a8377f4aee28c00bfd5b2a5a0efc7ce/src/Reopt.hs#L2429) are derived from the events passed to [recoverX86Elf](https://github.com/GaloisInc/reopt/blob/2a31c01d1df166f40c0c4800ef65f46d58dc4f8b/src/Reopt.hs#L2135)'s logger (i.e., the first parameter), as can be seen in the [recoverLogEvent](https://github.com/GaloisInc/reopt/blob/abd456341a8377f4aee28c00bfd5b2a5a0efc7ce/src/Reopt.hs#L2522) function.