### PR TITLE
reopt: log block size

### DIFF
--- a/src/Reopt.hs
+++ b/src/Reopt.hs
@@ -406,6 +406,7 @@ checkBlockError b = do
       Just $! DiscoveryError {
           discErrorTag = DiscoveryPLTErrorTag,
           discErrorBlockAddr = a,
+          discErrorBlockSize = blockSize b,
           discErrorBlockInsnIndex = length (pblockStmts b),
           discErrorMessage = "Unexpected PLT stub outside PLT"
         }
@@ -413,6 +414,7 @@ checkBlockError b = do
       Just $! DiscoveryError {
           discErrorTag = DiscoveryTransErrorTag,
           discErrorBlockAddr = a,
+          discErrorBlockSize = blockSize b,
           discErrorBlockInsnIndex = length (pblockStmts b),
           discErrorMessage = msg
         }
@@ -420,6 +422,7 @@ checkBlockError b = do
       Just $! DiscoveryError {
           discErrorTag = DiscoveryClassErrorTag,
           discErrorBlockAddr = a,
+          discErrorBlockSize = blockSize b,
           discErrorBlockInsnIndex = length (pblockStmts b),
           discErrorMessage = "Unclassified control flow transfer."
         }

--- a/src/Reopt/CFG/Recovery.hs
+++ b/src/Reopt/CFG/Recovery.hs
@@ -306,6 +306,7 @@ data RecoverState arch ids =
      , rsInsnIndex :: !Int
      , rsBlockOff :: !(ArchAddrWord arch)
      -- ^ The offset in the block of the current code.
+     , rsBlockSize :: !Int
      , _rsCurStmts  :: !(Seq (FnStmt arch))
        -- ^ Statements added to block so far
        -- | Maps assignments processed so far to their values
@@ -362,10 +363,12 @@ addFnStmt stmt = rsCurStmts %= (Seq.|> stmt)
 throwErrorAt :: ReoptErrorTag -> String -> Recover ids a
 throwErrorAt tag msg = do
   sa <- gets rsStartAddr
+  sz <- gets rsBlockSize
   idx <- gets rsInsnIndex
   throwError $ RecoverErrorAt {
     recoverErrorTag = tag,
-    recoverErrorBlock  = sa,
+    recoverErrorBlock = sa,
+    recoverErrorBlockSize = sz,
     recoverErrorInsnIndex = idx,
     recoverErrorMessage = Text.pack msg
   }
@@ -1371,6 +1374,7 @@ evalRecover b inv preds phiVars locMap = do
               , rsPhiLocMap = locMap
               , rsInsnIndex = 0
               , rsBlockOff = 0
+              , rsBlockSize = blockSize b
               , _rsCurStmts = Seq.empty
               , _rsAssignMap = MapF.empty
               , rsWriteMap = Map.empty

--- a/src/Reopt/Events.hs
+++ b/src/Reopt/Events.hs
@@ -163,6 +163,7 @@ instance Semigroup DiscoveryErrorTag where
 data DiscoveryError = DiscoveryError
   { discErrorTag :: !DiscoveryErrorTag,
     discErrorBlockAddr :: !Word64,
+    discErrorBlockSize :: !Int,
     -- | Instruction index.
     discErrorBlockInsnIndex :: !Int,
     discErrorMessage :: !Text
@@ -174,6 +175,7 @@ data DiscoveryError = DiscoveryError
 data RecoverError w = RecoverErrorAt
   { recoverErrorTag :: !ReoptErrorTag,
     recoverErrorBlock :: !(MemSegmentOff w),
+    recoverErrorBlockSize :: !Int,
     recoverErrorInsnIndex :: !Int,
     recoverErrorMessage :: !Text
   }


### PR DESCRIPTION
This adds block size to the `CFGError` datatype so that IDE frontends can decide to highlight the whole block.

I'm a little spooked by the two unlabeled `Int` fields, if this datatype becomes any more populated it probably ought to have named fields.