### PR TITLE
feat: reopt memcmp support for LLVM trans (i.e., 'repx cmpsx' in x86)

### DIFF
--- a/src/Reopt/CFG/LLVM.hs
+++ b/src/Reopt/CFG/LLVM.hs
@@ -46,6 +46,7 @@ module Reopt.CFG.LLVM
   , shl
   , icmpop
   , fcmpop
+  , cmpsxFromSize
   , llvmAsPtr
   , extractValue
   , insertValue
@@ -581,6 +582,16 @@ icmpop f val s = do
 fcmpop :: L.FCmpOp -> L.Typed L.Value -> L.Value -> BBLLVM arch (L.Typed L.Value)
 fcmpop f val s = do
   L.Typed (L.iT 1) <$> evalInstr (L.FCmp f val s)
+
+
+-- | Given a byte size, return the appropriate mnemonic, i.e.,
+-- one of `cmpsb` (1), `cmpsw` (2), `cmpsd` (4), or `cmpsq` (8).
+cmpsxFromSize :: Integer -> Maybe String
+cmpsxFromSize 1 = Just "cmpsb"
+cmpsxFromSize 2 = Just "cmpsw"
+cmpsxFromSize 4 = Just "cmpsd"
+cmpsxFromSize 8 = Just "cmpsq"
+cmpsxFromSize _ = Nothing
 
 
 -- | Extract a value from a struct


### PR DESCRIPTION
Adds support for translating Macaw's [MemCmp](https://github.com/GaloisInc/macaw/blob/e4b198ab2dd882e34690ed33056d5231b2d776bf/x86/src/Data/Macaw/X86/ArchTypes.hs#L373) x86 primitive to LLVM, which is used to support `repx cmpsx` occurrences in machine code which compare blocks of memory.

Makes small but non-zero improvements to recovery statistics:
```
diff -U1 pre_pr.txt post_pr.txt 
--- pre_pr.txt	2021-08-09 12:18:18.000000000 -0700
+++ post_pr.txt	2021-08-12 10:59:51.000000000 -0700
@@ -28,6 +28,7 @@
 Recovery:
-  Succeeded: 21,868 (72%)
-  Failed: 8,353 (28%)
-    Unsupported function value: 2,396 (8%)
-    Unimplemented LLVM backend feature: 4,881 (16%)
+  Succeeded: 21,952 (73%)
+  Failed: 8,269 (27%)
+    Unsupported function value: 2,425 (8%)
+    Unimplemented feature: 6 (0%)
+    Unimplemented LLVM backend feature: 4,762 (16%)
     Stack offset escape: 83 (0%)
```

Full statistics:
```
reopt analyzed 394 binaries:
Generated LLVM bitcode for 394 out of 394 binaries.
Initialization:
  Code segment: 42,933,178 bytes
  Initial entry points: 79776
  Warnings: 0
Discovery:
  Bytes discovered: 23,025,164 (54%)
  Succeeded: 64,494 (81%)
  Failed: 15,500 (19%)
    Unhandled instruction: 425 (1%)
    Unidentified control flow: 15,075 (19%)
Argument Analysis:
  Succeeded: 40,429 (63%)
  Failed: 24,065 (37%)
  Header Warnings: 0
  DWARF Warnings: 0
  Code Warnings: 38,681
Invariant Inference:
  Succeeded: 30,221 (75%)
  Failed: 10,208 (25%)
    Symbolic call stack height: 1 (0%)
    Unresolved stack read: 13 (0%)
    Indirect call target: 526 (1%)
    Call target not function entry point: 41 (0%)
    Unresolved call target arguments: 9,614 (24%)
    Could not resolve varargs args: 13 (0%)
Recovery:
  Succeeded: 21,952 (73%)
  Failed: 8,269 (27%)
    Unsupported function value: 2,425 (8%)
    Unimplemented feature: 6 (0%)
    Unimplemented LLVM backend feature: 4,762 (16%)
    Stack offset escape: 83 (0%)
    Stack read overlapping offset: 1 (0%)
    Unresolved return value: 8 (0%)
    Missing variable value: 984 (3%)
```