### PR TITLE
fix: update example reopt flags

### DIFF
--- a/examples/add/Makefile
+++ b/examples/add/Makefile
@@ -21,8 +21,8 @@ add_diet_lld.reopt.exe : add_diet_lld.exe add_protos.h
 
 # Generate LLVM file using reopt for add example
 add_diet_reopt.ll add_diet_reopt.ann : add_diet_lld.exe add_protos.h
-	reopt -o add_diet_reopt.ll --llvm --annotations add_diet_reopt.ann \
-               --header add_protos.h --include add --include main $<
+	reopt --export-llvm add_diet_reopt.ll --annotations add_diet_reopt.ann \
+        --header add_protos.h --include add --include main $<
 	python -m json.tool add_diet_reopt.ann > add_diet_reopt.ann.pretty
 	mv add_diet_reopt.ann.pretty add_diet_reopt.ann
 

--- a/examples/fib/Makefile
+++ b/examples/fib/Makefile
@@ -21,8 +21,8 @@ fib_diet_lld.reopt.exe : fib_diet_lld.exe fib_protos.h
 
 # Generate LLVM file using reopt for fib example
 fib_diet_reopt.ll fib_diet_reopt.ann : fib_diet_lld.exe fib_protos.h
-	reopt -o fib_diet_reopt.ll --llvm --annotations fib_diet_reopt.ann \
-               --header fib_protos.h --include fib --include main $<
+	reopt --export-llvm fib_diet_reopt.ll --annotations fib_diet_reopt.ann \
+        --header fib_protos.h --include fib --include main $<
 	python -m json.tool fib_diet_reopt.ann > fib_diet_reopt.ann.pretty
 	mv fib_diet_reopt.ann.pretty fib_diet_reopt.ann
 

--- a/examples/nweb/Makefile
+++ b/examples/nweb/Makefile
@@ -18,7 +18,7 @@ nweb23.exe : nweb23.c
 	$(clang) -o $@ -g $<
 
 nweb23.ll nweb23.ann : nweb23.exe nweb23.h
-	reopt --llvm -o nweb23.ll --annotations nweb23.ann --header nweb23.h nweb23.exe || true
+	reopt --export-llvm nweb23.ll --annotations nweb23.ann --header nweb23.h nweb23.exe || true
 	python -m json.tool nweb23.ann > nweb23.ann.pretty
 	mv nweb23.ann.pretty nweb23.ann
 


### PR DESCRIPTION
With these changes, if I visit the Gitpod link which includes them (i.e., https://gitpod.io/#https://github.com/GaloisInc/reopt/tree/pnwamk/try-reopt in this case) I am able to `cd` into each subdirectory in the `examples` directory and run `make`, which builds the executable, runs `reopt`, and then runs `reopt-vcg`.

The only failures are the few known remaining issues for our `nweb` example's verification condition checking, i.e.:
```
Generating verification conditions for LLVM module...
........................................................................................................................
FAIL
    reopt_frame_dummy_0_0x4012b0.block_0_4012b0.0 @ 0x4012b4: return address is next instruction
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/reopt_frame_dummy_0_0x4012b0_block_0_4012b0_1.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/reopt_frame_dummy_0_0x4012b0_block_0_4012b0_1.smt2`
..........................................................................................................................................................................................................................................................
FAIL
    web.block_0_4015e8.2 @ 0x4015ec: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_4015e8_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_4015e8_2.smt2`
...............................
FAIL
    web.block_0_4015fd.2 @ 0x401601: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_4015fd_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_4015fd_2.smt2`
..............................................................................................................................................................................................................................................
FAIL
    web.block_0_4016da.2 @ 0x4016de: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_4016da_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_4016da_2.smt2`
.........................................................................................................
FAIL
    web.block_0_401732.3 @ 0x401736: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401732_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401732_2.smt2`
...............................
FAIL
    web.block_0_401747.4 @ 0x401750: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401747_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401747_2.smt2`
...................................................................................................................................................................................................................................
FAIL
    web.block_0_401815.3 @ 0x40182a: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401815_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401815_2.smt2`
.................................
FAIL
    web.block_0_401834.3 @ 0x40184c: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401834_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401834_2.smt2`
.............................
FAIL
    web.block_0_401858.6 @ 0x401880: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401858_6.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401858_6.smt2`
............................................................
FAIL
    web.block_0_401898.3 @ 0x4018ad: read heap address not in stack space
    Verification failed: the SMT query returned `sat`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401898_2.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401898_2.smt2`
........................................................................................................................................................................................................................................................................................................................................................................................................................................................
FAIL
    web.block_0_401a6a.1 @ 0x401a72: stack height preserved (after return)
    Verification failed: the SMT query returned `unknown`

    To see the output, run `reopt-vcg nweb23.ann --export <dir>`
    The SMT query will be stored in <dir>/web_block_0_401a6a_5.smt2
    The default invocation of CVC4 for these queries is as follows:
      `cvc4 --lang=smt2 --arrays-exp --no-fmf-bound --incremental <dir>/web_block_0_401a6a_5.smt2`
............................
======================= 4 VC GENERATION WARNINGS =======================
web.block_0_401815.3 @ 0x401815: LLVM alignment of 8  is unchecked.
web.block_0_401834.3 @ 0x401834: LLVM alignment of 8  is unchecked.
web.block_0_401858.6 @ 0x401858: LLVM alignment of 8  is unchecked.
web.block_0_401898.3 @ 0x401898: LLVM alignment of 8  is unchecked.

All 8 functions were assigned verification conditions without error.

====================== GOAL VERIFICATION SUMMARY =======================
1581 out of 1592 generated verification goals successfully proven.

11 goals failed to be verified:
* (9) read heap address not in stack space
    - (9) no additional information
* (1) stack height preserved
    - (1) after return
* (1) return address is next instruction
    - (1) no additional information
make: *** [Makefile:9: nweb23.crt] Error 1
```