### PR TITLE
initial implementation of types and constraints

### DIFF
--- a/reopt.cabal
+++ b/reopt.cabal
@@ -85,6 +85,7 @@ library
     Reopt.Relinker.Redirection
     Reopt.Relinker.Relations
     Reopt.Relinker.Relocations
+    Reopt.TypeInference.Constraints
     Reopt.TypeInference.DebugTypes
     Reopt.TypeInference.Header
     Reopt.TypeInference.HeaderTypes

--- a/reopt.cabal
+++ b/reopt.cabal
@@ -184,6 +184,7 @@ executable reopt-relink
 test-suite reopt-tests
   type: exitcode-stdio-1.0
   default-language: Haskell2010
+  ghc-options: -Wall
   main-is: Main.hs
   other-modules:
     ReoptTests

--- a/reopt.cabal
+++ b/reopt.cabal
@@ -184,7 +184,6 @@ executable reopt-relink
 test-suite reopt-tests
   type: exitcode-stdio-1.0
   default-language: Haskell2010
-  ghc-options: -Wall
   main-is: Main.hs
   other-modules:
     ReoptTests

--- a/reopt.cabal
+++ b/reopt.cabal
@@ -64,6 +64,7 @@ library
     Reopt.PltParser
     Reopt.Relinker.Binary
     Reopt.Server
+    Reopt.TypeInference.Constraints
     Reopt.TypeInference.FunTypeMaps
     Reopt.Utils.Dir
     Reopt.Utils.Exit
@@ -85,7 +86,6 @@ library
     Reopt.Relinker.Redirection
     Reopt.Relinker.Relations
     Reopt.Relinker.Relocations
-    Reopt.TypeInference.Constraints
     Reopt.TypeInference.DebugTypes
     Reopt.TypeInference.Header
     Reopt.TypeInference.HeaderTypes
@@ -186,7 +186,8 @@ test-suite reopt-tests
   default-language: Haskell2010
   ghc-options: -Wall
   main-is: Main.hs
-  other-modules: ReoptTests
+  other-modules:
+    ReoptTests
   hs-source-dirs: tests
   build-depends:
     base,

--- a/reopt.cabal
+++ b/reopt.cabal
@@ -188,6 +188,7 @@ test-suite reopt-tests
   main-is: Main.hs
   other-modules:
     ReoptTests
+    TyConstraintTests
   hs-source-dirs: tests
   build-depends:
     base,

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 -- Loosely based on 'TIE: Principled Reverse Engineering of Types in Binary
 -- Programs' (NDSS 2011) by Jonghyup Lee, Thanassis Avgerinos, and David Brumley
 
@@ -5,52 +6,62 @@
 module Reopt.TypeInference.Constraints where
 
 
-
-data Ty
-  = TyData DataTy
-  | TyFun
-  | TyTop
-  | TyBot
-  | TyAnd Ty Ty
-  | TyOr Ty Ty
-  | TyArrow Ty Ty
-
-data DataTy
-  = DTyBase BaseTy
-  | DTyMem MemTy
+data NumSize
+  = NumSize8
+  | NumSize16
+  | NumSize32
+  | NumSize64
+  deriving (Eq, Ord)
 
 
-data BaseTy
-  = BTyBase RegTy
-  | BTyRefined RefinedTy
+newtype TyVar = TyVar {tyVarInt :: Int }
+  deriving (Eq, Ord)
 
--- | Maps each memory cell address to the type stored at that address.
-data MemTy = MemTy -- ??? {∀ addresses i|li : Ti } wut is that? a set of address/type mappings?
+-- | Types of values in x86 machine code
+data X86Ty
+  = UnknownTy -- the top type
+  | AbsurdTy -- the bottom type
+  | VarTy TyVar -- a type unification variable
+  | PtrTy
+  | NumTy NumSize
+  | ScalarFloatTy
+  | VecFloatTy
+  deriving (Eq, Ord)
+
+-- | x86 type constraints
+data X86TyConstraint
+  = -- | These types are known to be equal.
+    EqC X86Ty X86Ty
+  -- | These types were used in an addition operation of width @NumSize@.
+  | AddC NumSize X86Ty X86Ty
+
+numSizeInt :: NumSize -> Int
+numSizeInt =
+  \case
+    NumSize8 -> 8
+    NumSize16 -> 16
+    NumSize32 -> 32
+    NumSize64 -> 64
+
+-- | @subtype t1 t2@ returns @True@ iff @t1@ is a subtype of @t2@.
+subtype :: X86Ty -> X86Ty -> Bool
+subtype t1 t2 =
+  case (t1,t2) of
+    (_,_) | t1 == t2 -> True
+    (_, UnknownTy) -> True
+    (AbsurdTy, _) -> True
+    (NumTy n1, NumTy n2) -> (numSizeInt n1) <= (numSizeInt n2)
+    (_,_) -> False
 
 
 
--- | Register types, Cf. τ_reg
-data RegTy
-  = Reg1Ty
-  | Reg8Ty
-  | Reg16Ty
-  | Reg32Ty
-  | Reg64Ty
 
+-- -- | Calculates the least upper bound of two types (denoted by the “join”
+-- operator ⊔).
+-- join :: Ty -> Ty -> Ty
+-- join  = undefined -- FIXME
 
--- | Refined types, Cf. τ_refined
-data RefinedTy
-  = Num8RTy
-  | Num16RTy
-  | Num32RTy
-  | Num64RTy
-  | UInt8RTy
-  | UInt16RTy
-  | UInt32RTy
-  | UInt64RTy
-  | Int8RTy
-  | Int16RTy
-  | Int32RTy
-  | Int64RTy
-  | PtrRTy Ty
-  | CodeRTy
+-- -- | Calculates the greatest lower bound of two types (denoted by the meet”
+-- -- operator ⊓).
+-- meet :: Ty -> Ty -> Ty
+-- meet  = undefined -- FIXME

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- Loosely based on 'TIE: Principled Reverse Engineering of Types in Binary
 -- Programs' (NDSS 2011) by Jonghyup Lee, Thanassis Avgerinos, and David Brumley
 
 -- Not clear yet how much will directly be applicable etc.
 module Reopt.TypeInference.Constraints where
 
-
-import Data.Text (Text)
+import Control.Monad.State
+    ( when, State, gets, execState, modify' )
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Data.Map.Lazy as LazyMap
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Prettyprinter as PP
@@ -18,6 +18,10 @@ import qualified Prettyprinter as PP
 -- import qualified Data.List.NonEmpty as NonEmpty
 
 import Debug.Trace ( trace )
+
+-- | Set to @True@ to enable tracing in unification
+traceUnification :: Bool
+traceUnification = False
 
 newtype TyVar = TyVar {tyVarInt :: Int }
   deriving (Eq, Ord, Show)
@@ -153,56 +157,110 @@ concretize :: Ty -> (TyVar -> Ty) -> Ty
 concretize initialTy lookupVar = go initialTy
   where
     go :: Ty -> Ty
-    go TopTy = TopTy
-    go BotTy = BotTy
-    go (VarTy x) = lookupVar x
-    go (PtrTy w t) = ptrTy w (go t)
-    go t@CodeTy{} = t
-    go t@RegTy{} = t
-    go t@NumTy{} = t
-    go t@IntTy{} = t
-    go t@UIntTy{} = t
+    go TopTy       = TopTy
+    go BotTy       = BotTy
+    go t@CodeTy{}  = t
+    go t@RegTy{}   = t
+    go t@NumTy{}   = t
+    go t@IntTy{}   = t
+    go t@UIntTy{}  = t
     go t@FloatTy{} = t
-    go (AndTy t1 t2 ts) = andTy $ (go t1):(go t2):(map go ts)
-    go (OrTy t1 t2 ts) = orTy $ (go t1):(go t2):(map go ts)
+    go (VarTy x)   = lookupVar x
+    go (PtrTy w t) = ptrTy w (go t)
+    go (AndTy t1 t2 ts) = andTy $ map go (t1:t2:ts)
+    go (OrTy t1 t2 ts)  = orTy  $ map go (t1:t2:ts)
 
+-- | @concretize@ except in a monadic context.
+concretizeM :: forall m. Monad m => Ty -> (TyVar -> m Ty) -> m Ty
+concretizeM initialTy lookupVar = go initialTy
+  where
+    go :: Ty -> m Ty
+    go TopTy       = pure TopTy
+    go BotTy       = pure BotTy
+    go t@CodeTy{}  = pure t
+    go t@RegTy{}   = pure t
+    go t@NumTy{}   = pure t
+    go t@IntTy{}   = pure t
+    go t@UIntTy{}  = pure t
+    go t@FloatTy{} = pure t
+    go (VarTy x)   = lookupVar x
+    go (PtrTy w t) = ptrTy w <$> (go t)
+    go (AndTy t1 t2 ts) = andTy <$> mapM go (t1:t2:ts)
+    go (OrTy t1 t2 ts)  = orTy  <$> mapM go (t1:t2:ts)
 
 -- | @subst x t1 t2@ says substitute appearances of @x@ out for @t1@ in @t2@.
 subst :: TyVar -> Ty -> Ty -> Ty
 subst x xTy ty = concretize ty (\y -> if x == y then xTy else (VarTy y))
 
-subtype :: Ty -> Ty -> Bool
-subtype type1 type2 =
-  case (type1,type2) of
-    -- Reflexivity
-    (s,t) | s == t -> True
-    -- Top/Bot
-    (_, TopTy) -> True
-    (BotTy, _) -> True
-    -- Pointer subtypes
-    (PtrTy w1 s, PtrTy w2 t) -> w1 <= w2 && subtype s t
-    -- Register subtypes
-    (RegTy w1,   RegTy w2) -> w1 <= w2
-    (PtrTy w1 _, RegTy w2) -> w1 <= w2
-    (CodeTy w1,  RegTy w2) -> w1 <= w2
-    (NumTy w1,   RegTy w2) -> w1 <= w2
-    (IntTy w1,   RegTy w2) -> w1 <= w2
-    (UIntTy w1,  RegTy w2) -> w1 <= w2
-    -- Numeric (signed/unsigned integer) subtypes
-    (NumTy w1,  NumTy w2) -> w1 <= w2
-    (IntTy w1,  NumTy w2) -> w1 <= w2
-    (UIntTy w1, NumTy w2) -> w1 <= w2
-    -- Signed/Unsigned integer subtypes
-    (IntTy w1,  IntTy w2)  -> w1 <= w2
-    (UIntTy w1, UIntTy w2) -> w1 <= w2
-    -- Set-theoretic subtypes
-    (AndTy s1 s2 ss, t) -> any (\s -> subtype s t) (s1:s2:ss)
-    (OrTy s1 s2 ss, t)  -> all (\s -> subtype s t) (s1:s2:ss)
-    (s, AndTy t1 t2 ts) -> all (subtype s) (t1:t2:ts)
-    (s, OrTy t1 t2 ts)  -> any (subtype s) (t1:t2:ts)
-    -- Conservative base case
-    (_, _) -> False
+-- | @subtype' f g s t@ computes whether `s <: t` holds, applying @f@ to resolve
+-- type variables on the left and @g@ to resolve type variables on the right.
+subtype' :: (TyVar -> Ty) -> (TyVar -> Ty) -> Ty -> Ty -> Bool
+subtype' resolveL resolveR = go
+  where
+    go :: Ty -> Ty -> Bool
+    go type1 type2 =
+      case (type1,type2) of
+        -- Reflexivity
+        (s,t) | s == t -> True
+        -- Top/Bot
+        (_, TopTy) -> True
+        (BotTy, _) -> True
+        -- Pointer subtypes
+        (PtrTy w1 s, PtrTy w2 t) -> w1 <= w2 && go s t
+        -- Register subtypes
+        (RegTy w1,   RegTy w2) -> w1 <= w2
+        (PtrTy w1 _, RegTy w2) -> w1 <= w2
+        (CodeTy w1,  RegTy w2) -> w1 <= w2
+        (NumTy w1,   RegTy w2) -> w1 <= w2
+        (IntTy w1,   RegTy w2) -> w1 <= w2
+        (UIntTy w1,  RegTy w2) -> w1 <= w2
+        -- Numeric (signed/unsigned integer) subtypes
+        (NumTy w1,  NumTy w2) -> w1 <= w2
+        (IntTy w1,  NumTy w2) -> w1 <= w2
+        (UIntTy w1, NumTy w2) -> w1 <= w2
+        -- Signed/Unsigned integer subtypes
+        (IntTy w1,  IntTy w2)  -> w1 <= w2
+        (UIntTy w1, UIntTy w2) -> w1 <= w2
+        -- Set-theoretic subtypes
+        (AndTy s1 s2 ss, t) -> any (\s -> go s t) (s1:s2:ss)
+        (OrTy s1 s2 ss, t)  -> all (\s -> go s t) (s1:s2:ss)
+        (s, AndTy t1 t2 ts) -> all (go s) (t1:t2:ts)
+        (s, OrTy t1 t2 ts)  -> any (go s) (t1:t2:ts)
+        -- Type Variable special handling
+        (VarTy x, t) -> let xTy = resolveL x in
+                          if xTy == type1
+                            then False
+                            else go xTy t
+        (s, VarTy y) -> let yTy = resolveR y in
+                          if yTy == type2
+                            then False
+                            else go s yTy
+        -- Conservative base case
+        (_, _) -> False
 
+-- | Whether `s <: t` holds. This function is sound but not complete (i.e., with
+-- a _syntactic_ treatment of set-theoretic types, it is _possible_ to return
+-- @False@ erroneously, but @True@ is always sound).
+subtype :: Ty -> Ty -> Bool
+subtype = subtype' VarTy VarTy
+
+-- | Sound but possibly incomplete check if the type is uninhabited. I.e.,
+-- @True@ means the type _is_ uninhabited, but @False@ could mean the type is
+-- _possibly_ uninhabited (i.e., set-theoretic types can get complicated).
+uninhabited :: Ty -> Bool
+uninhabited = \case
+  TopTy -> False
+  BotTy -> True
+  VarTy{} -> False
+  PtrTy _ ty -> uninhabited ty
+  CodeTy{} -> False
+  RegTy{} -> False
+  NumTy{} -> False
+  UIntTy{} -> False
+  IntTy{} -> False
+  FloatTy{} -> False
+  AndTy t1 t2 ts -> any uninhabited (t1:t2:ts) -- conservative
+  OrTy  t1 t2 ts -> any uninhabited (t1:t2:ts)
 
 -- | Calculates the (least) upper bound of two types (denoted by the “join”
 -- operator ⊔).
@@ -260,7 +318,11 @@ occursIn x ty = Set.member x $ tyFreeVars ty
 
 -- | x86 type constraints
 data TyConstraint
-  = -- | An equality constraint.
+  = -- | The trivial constraint.
+    TopC
+  | -- | The absurd constraint.
+    BotC
+  |  -- | An equality constraint.
     EqC Ty Ty
   | -- | A subtype constraint.
     SubC Ty Ty
@@ -269,6 +331,8 @@ data TyConstraint
   deriving (Eq, Ord, Show)
 
 instance PP.Pretty TyConstraint where
+  pretty TopC = "tt"
+  pretty BotC = "ff"
   pretty (EqC l r) = (PP.pretty l) PP.<+> "=" PP.<+> (PP.pretty r)
   pretty (SubC l r) = (PP.pretty l) PP.<+> "<:" PP.<+> (PP.pretty r)
   pretty (OrC c1 c2 cs) = PP.parens $ PP.hsep $ "or":(map (\c -> PP.parens $ PP.pretty c) (c1:c2:cs))
@@ -282,6 +346,8 @@ andC = go Set.empty
                       [] -> EqC TopTy TopTy
                       [c] -> c
                       c1:c2:cs -> AndC c1 c2 cs
+        go _   (BotC:_) = BotC
+        go acc (TopC:cs) = go acc cs
         go acc (c@EqC{}:cs) = go (Set.insert c acc) cs
         go acc (c@SubC{}:cs) = go (Set.insert c acc) cs
         go acc (AndC c1 c2 cs:cs') = go acc (c1:c2:(cs++cs'))
@@ -296,10 +362,22 @@ orC = go Set.empty
                       [] -> EqC BotTy TopTy
                       [c] -> c
                       c1:c2:cs -> OrC c1 c2 cs
+        go acc (BotC:cs) = go acc cs
+        go _   (TopC:_) = TopC
         go acc (c@EqC{}:cs) = go (Set.insert c acc) cs
         go acc (c@SubC{}:cs) = go (Set.insert c acc) cs
         go acc (OrC c1 c2 cs:cs') = go acc (c1:c2:(cs++cs'))
         go acc (c@AndC{}:cs) = go (Set.insert c acc) cs
+
+
+cFreeVars :: TyConstraint -> Set TyVar
+cFreeVars TopC = Set.empty
+cFreeVars BotC = Set.empty
+cFreeVars (EqC s t) = Set.union (tyFreeVars s) (tyFreeVars t)
+cFreeVars (SubC s t) = Set.union (tyFreeVars s) (tyFreeVars t)
+cFreeVars (OrC c1 c2 cs) = foldr Set.union Set.empty $ map cFreeVars (c1:c2:cs)
+cFreeVars (AndC c1 c2 cs) = foldr Set.union Set.empty $ map cFreeVars (c1:c2:cs)
+
 
 -- cSubst :: TyVar -> Ty -> TyConstraint -> TyConstraint
 -- cSubst x xTy constraint = go constraint
@@ -334,6 +412,8 @@ data Context
     , ctxOccursCheckFailures :: [(Ty, Ty)]
     , -- | Subtype constraints, i.e. each `(s,t)` means `s <: t`. Cf. `C` from TIE § 6.3.
       ctxSubConstraints :: [(Ty, Ty)]
+      -- | Constraints that were deemed to be absurd.
+    , ctxAbsurdConstraints :: [TyConstraint]
     , -- | Disjunctive constraints, i.e. each `[c1,c2,...]` means `c1 ∨ c2 ∨ ...`. Cf. `C` from TIE § 6.3.
       ctxOrConstraints  :: [[TyConstraint]]
       -- | Map from type variables to their known subtypes and supertypes.
@@ -341,7 +421,7 @@ data Context
     , ctxSubtypeMap :: Map TyVar (Set Ty, Set Ty)
     -- | Known type for type variables. `S_{=}` from TIE § 6.3. N.B., this map
     -- is used in conjunction with `substEqs` to apply substitutions lazily.
-    , ctxVarTypeMap :: Map TyVar Ty
+    , ctxVarEqMap :: Map TyVar Ty
     -- | Lower and upper bounds for type variables. `B^{↓}` and `B^{↑}` from TIE § 6.3.
     , ctxVarBoundsMap :: Map TyVar (Ty, Ty)
     }
@@ -355,29 +435,37 @@ instance PP.Pretty Context where
                   , row "Dropped Equalities" $ map (binop "=") $ ctxDroppedEqConstraints ctx
                   , row "Occurs check failures" $ map (binop "=") $ ctxOccursCheckFailures ctx
                   , row "Subtypes" $ map (binop "<:") $ ctxSubConstraints ctx
+                  , row "Absurd Constraints" $ map PP.pretty $ ctxAbsurdConstraints ctx
                   , row "Ors" $ map (\cs -> PP.list $ map PP.pretty cs) $ ctxOrConstraints ctx
                   , row "S_{<:}" $ map (\(x,(ls,us)) -> (PP.encloseSep "{" "}" "," $ map PP.pretty $ Set.toList ls)
                                                       PP.<+> "<:" PP.<+> PP.pretty x PP.<+> "<:"
                                                       PP.<+> (PP.encloseSep "{" "}" "," $ map PP.pretty $ Set.toList us))
                                  $ Map.toList $ ctxSubtypeMap ctx
-                  , row "S_{=}" $ map (binop "↦") $ Map.toList $ ctxVarTypeMap ctx
+                  , row "S_{=}" $ map (binop "↦") $ Map.toList $ ctxVarEqMap ctx
                   , row "B^{↓}/B^{↑}" $ map (\(x,(l,u)) -> PP.pretty l PP.<+> "<:" PP.<+> PP.pretty x PP.<+> "<:" PP.<+> PP.pretty u)
                                       $ Map.toList $ ctxVarBoundsMap ctx
                   ]
 
-dequeueEqC :: Context -> Maybe ((Ty,Ty), Context)
+-- | Does the context have any equality or subtype constraints left to process?
+hasAtomicConstraints :: Context -> Bool
+hasAtomicConstraints ctx =
+  ctxEqConstraints ctx /= [] || ctxSubConstraints ctx /= []
+
+dequeueEqC :: Context -> Maybe (Context, (Ty,Ty))
 dequeueEqC ctx = case ctxEqConstraints ctx of
                   [] -> Nothing
-                  c:cs -> Just (c,ctx{ctxEqConstraints=cs})
+                  c:cs -> Just (ctx{ctxEqConstraints=cs},c)
 
-dequeueSubC :: Context -> Maybe ((Ty,Ty), Context)
+dequeueSubC :: Context -> Maybe (Context, (Ty,Ty))
 dequeueSubC ctx = case ctxSubConstraints ctx of
                    [] -> Nothing
-                   c:cs -> Just (c,ctx{ctxSubConstraints=cs})
+                   c:cs -> Just (ctx{ctxSubConstraints=cs},c)
 
 
 addConstraints :: [TyConstraint] -> Context -> Context
 addConstraints [] ctx = ctx
+addConstraints (TopC:cs) ctx = addConstraints cs ctx
+addConstraints (BotC:cs) ctx = addConstraints cs ctx{ctxAbsurdConstraints = BotC:ctxAbsurdConstraints ctx}
 addConstraints ((EqC  t1 t2):cs) ctx =
     addConstraints cs (ctx {ctxEqConstraints = (t1,t2):ctxEqConstraints ctx})
 addConstraints ((SubC t1 t2):cs) ctx =
@@ -387,61 +475,82 @@ addConstraints ((OrC c1 c2 cs'):cs) ctx =
 addConstraints ((AndC c1 c2 cs'):cs) ctx =
     addConstraints (c1:c2:cs'++cs) ctx
 
-
--- | Perform the substitutions implied thus far by the @Context@'s
--- @ctxVarTypes@ map. (This is to avoid performing repeated substitutions on the
--- entire constraint set.)
-substEqs :: Ty -> Context -> Ty
-substEqs t cinfo = concretize t lookupVar
-  where lookupVar x = Map.findWithDefault (VarTy x) x (ctxVarTypeMap cinfo)
-
--- | Concretize the type using any available upper bounds for type variables.
-currentUpperBound :: Ty -> Context -> Ty
-currentUpperBound t cinfo = concretize t lookupVar
-  where lookupVar x = snd $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap cinfo)
-
--- | Concretize the type using any available lower bounds for type variables.
-currentLowerBound :: Ty -> Context -> Ty
-currentLowerBound t cinfo = concretize t lookupVar
-  where lookupVar x = fst $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap cinfo)
-
 emptyContext :: Context
-emptyContext = Context [] [] [] [] [] Map.empty Map.empty Map.empty
+emptyContext = Context [] [] [] [] [] [] Map.empty Map.empty Map.empty
 
 -- | Partition the constraints into the @Context@, which we use to order
 -- which are handled when during unification.
 initContext :: [TyConstraint] -> Context
 initContext constraints = addConstraints constraints emptyContext
 
--- FIXME use S_{=} to not actually do full substitutions all the time and just
--- do them _as_ we consider constraints...? Use a newtype?
+-- | Perform the substitutions implied thus far by the @Context@'s
+-- @ctxVarTypes@ map. (This is to avoid performing repeated substitutions on the
+-- entire constraint set.)
+substEqs :: Ty -> Context -> Ty
+substEqs t ctx = concretize t lookupVar
+  where lookupVar x = Map.findWithDefault (VarTy x) x (ctxVarEqMap ctx)
+
+-- | Concretize the type using any available upper bounds for type variables.
+currentUpperBound :: Ty -> Context -> Ty
+currentUpperBound t ctx = concretize t lookupVar
+  where lookupVar x = snd $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap ctx)
+
+-- | Concretize the type using any available lower bounds for type variables.
+currentLowerBound :: Ty -> Context -> Ty
+currentLowerBound t ctx = concretize t lookupVar
+  where lookupVar x = fst $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap ctx)
+
+
+-- | Is this subtype constraint trivial in the current context?
+trivialSubC ::  Context -> Ty -> Ty -> Bool
+trivialSubC ctx s t = subtype' resolveVar resolveVar s t
+  where resolveVar x = Map.findWithDefault (VarTy x) x (ctxVarEqMap ctx)
+
+-- | @absurdSubC s t ctx@ returns @True@ if `s <: t` is an absurd constraint given `ctx`.
+-- N.B., this is intended to be a conservative check (i.e., sound but incomplete).
+absurdSubC ::  Context -> Ty -> Ty -> Bool
+absurdSubC ctx s t = not $ subtype' resolveL resolveR s t
+  where resolveL x = fst $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap ctx)
+        resolveR x = snd $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap ctx)
+
+-- | Is this equality constraint trivial in the current context?
+trivialEqC ::  Context -> Ty -> Ty -> Bool
+trivialEqC ctx s t = trivialSubC ctx s t && trivialSubC ctx t s
+
+-- | @absurdEqC s t ctx@ returns @True@ if `s = t` is an absurd constraint given `ctx`.
+absurdEqC :: Context -> Ty -> Ty -> Bool
+absurdEqC ctx s t = (absurdSubC ctx s t) || (absurdSubC ctx t s)
 
 -- | @traceContext description ctx ctx'@ reports how the context changed via @trace@.
 traceContext :: PP.Doc () -> Context -> Context -> Context
 traceContext description preCtx postCtx =
-  let msg = PP.vsep [PP.hsep [">>> ", description]
-                    , PP.indent 4 $ PP.pretty preCtx
-                    , PP.hsep ["<<< ", description]
-                    , PP.indent 4 $ PP.pretty postCtx]
-    in trace (show msg) postCtx
+  if not traceUnification then postCtx else
+    let msg = PP.vsep [PP.hsep [">>> ", description]
+                      , PP.indent 4 $ PP.pretty preCtx
+                      , PP.hsep ["<<< ", description]
+                      , PP.indent 4 $ PP.pretty postCtx]
+      in trace (show msg) postCtx
 
+traceCOpContext :: PP.Doc () -> TyConstraint -> Context -> Context -> Context
+traceCOpContext fnNm c ctx ctx' =
+  traceContext (fnNm<>"(" <> (PP.pretty $ c)<> ")") ctx ctx'
 
 -- | @solveEqC (s,t) ctx@ updates @ctx@ with the equality
 -- `s == t`. Cf. TIE Algorithm 1. If @Nothing@ is returned, the equality
 -- failed the occurs check. FIXME should we have a `decomposeEqC` similar to `decomposeSubC`?
-solveEqC :: (Ty,Ty) -> Context -> Context
-solveEqC (type1, type2) ctx =
-  traceContext ("solveEqC(" <> (PP.pretty $ EqC type1 type2)<> ")")
-  ctx
-  $ go (substEqs type1 ctx) (substEqs type2 ctx)
+solveEqC :: Context -> (Ty,Ty) -> Context
+solveEqC ctx (type1, type2) = traceCOpContext "solveEqC" (EqC type1 type2) ctx $
+  go (substEqs type1 ctx) (substEqs type2 ctx)
   where go :: Ty -> Ty -> Context
         go s@(VarTy x) t =
           if occursIn x t
             then ctx{ctxOccursCheckFailures=(s,t):(ctxOccursCheckFailures ctx)}
-            else ctx{ctxVarTypeMap = Map.insert x t (ctxVarTypeMap ctx)}
+            else ctx{ctxVarEqMap = Map.insert x t (ctxVarEqMap ctx)}
         go s t@(VarTy _) = go t s
         go (PtrTy _w1 s) (PtrTy _w2 t) = ctx {ctxEqConstraints = (s,t):ctxEqConstraints ctx}
-        go s t = ctx{ctxDroppedEqConstraints= (s,t):(ctxDroppedEqConstraints ctx)}
+        go s t = if absurdEqC ctx s t
+                 then ctx{ctxAbsurdConstraints = (EqC s t):ctxAbsurdConstraints ctx}
+                 else ctx{ctxDroppedEqConstraints= (s,t):(ctxDroppedEqConstraints ctx)}
 
 
 -- | @upperBoundsClosure s t ctx@ says given `s <: t`, for all type variables
@@ -452,9 +561,9 @@ solveEqC (type1, type2) ctx =
 -- only over known subtype constraints where `α` is _explicitly a type
 -- variable_.
 upperBoundsClosure :: Ty -> Ty -> Context -> Context
-upperBoundsClosure s t initial =
+upperBoundsClosure s t ctx0 = traceCOpContext "upperBoundsClosure" (SubC s t) ctx0 $
   -- Find all `α` where `α <: s` and perform updates to propogate `α <: t`.
-  Map.foldrWithKey update initial (ctxSubtypeMap initial)
+  Map.foldrWithKey update ctx0 (ctxSubtypeMap ctx0)
   where
     update :: TyVar -> (Set Ty, Set Ty) -> Context -> Context
     update a (lowerBounds,upperBounds) ctx =
@@ -483,9 +592,9 @@ upperBoundsClosure s t initial =
 -- only over known subtype constraints where `β` is _explicitly a type
 -- variable_.
 lowerBoundsClosure :: Ty -> Ty -> Context -> Context
-lowerBoundsClosure s t initial =
+lowerBoundsClosure s t ctx0 = traceCOpContext "lowerBoundsClosure" (SubC s t) ctx0 $
   -- Find all `β` where `t <: β` and perform updates to propogate `s <: β`.
-  Map.foldrWithKey update initial (ctxSubtypeMap initial)
+  Map.foldrWithKey update ctx0 (ctxSubtypeMap ctx0)
   where
     update :: TyVar -> (Set Ty, Set Ty) -> Context -> Context
     update b (lowerBounds,upperBounds) ctx =
@@ -509,7 +618,8 @@ lowerBoundsClosure s t initial =
 -- | @atomicSubUpdate s t ctx@ records the basic information relevant for `s <:
 -- t` (i.e., it does not compute the closure).
 atomicSubUpdate :: Ty -> Ty -> Context -> Context
-atomicSubUpdate type1 type2 = (updateLower type1 type2) . (updateUpper type1 type2)
+atomicSubUpdate type1 type2 ctx0 = traceCOpContext "atomicSubUpdate" (SubC type1 type2) ctx0 $
+  updateLower type1 type2 $ updateUpper type1 type2 ctx0
   where updateLower s (VarTy x) ctx =
           let sMap = ctxSubtypeMap ctx
               (lSet, uSet) = Map.findWithDefault (Set.empty, Set.empty) x sMap
@@ -525,63 +635,144 @@ atomicSubUpdate type1 type2 = (updateLower type1 type2) . (updateUpper type1 typ
               bMap = ctxVarBoundsMap ctx
               (lBound, uBound) = Map.findWithDefault (BotTy, TopTy) x bMap
               uBound' = lowerBound (currentUpperBound uBound ctx) (currentUpperBound t ctx)
-            in ctx { ctxSubtypeMap = Map.insert x (Set.insert t lSet, uSet) sMap
+            in ctx { ctxSubtypeMap = Map.insert x (lSet, Set.insert t uSet) sMap
                    , ctxVarBoundsMap = Map.insert x (lBound, uBound') bMap}
         updateUpper _ _ ctx = ctx
 
--- | @solveSubC (t1,t2) cset cinfo@ updates @cset@ and @cinfo@ with the subtype constraint
+-- | @solveSubC (t1,t2) cset ctx@ updates @cset@ and @ctx@ with the subtype constraint
 -- `t1 <: t2`. Cf. TIE § 6.3.2.
-solveSubC :: (Ty,Ty) -> Context -> Context
-solveSubC (type1,type2) ctx = traceContext ("solveSubC(" <> (PP.pretty $ SubC type1 type2)<> ")") ctx $
-  let t1 = substEqs type1 ctx
-      t2 = substEqs type2 ctx
+solveSubC :: Context -> (Ty,Ty) -> Context
+solveSubC ctx0 (type1,type2) = traceCOpContext "solveSubC" (SubC type1 type2) ctx0 $
+  let t1 = substEqs type1 ctx0
+      t2 = substEqs type2 ctx0
   in -- cycle check
-     if not $ Set.disjoint (tyFreeVars t1) (tyFreeVars t2) then ctx
+     if not $ Set.disjoint (tyFreeVars t1) (tyFreeVars t2) then ctx0
      -- If `t1 <: t2` the contraint is trivial and should be discarded.
-     else if subtype t1 t2 then ctx
-     -- FIXME What if `t1 <: t2` is unsatisfiable? probably should stop and
-     -- record that or similar instead of all the follow on computation.
+     else if subtype t1 t2 then ctx0
+     -- If `t1 <: t2` appears absurd, record that and continue.
+     else if absurdSubC ctx0 t1 t2 then ctx0{ctxAbsurdConstraints = (SubC t1 t2):ctxAbsurdConstraints ctx0}
      else addConstraints (decomposeSubC t1 t2)
-           $ lowerBoundsClosure t1 t2
-           $ upperBoundsClosure t1 t2
-           $ atomicSubUpdate t1 t2
-           $ ctx
+          $ lowerBoundsClosure t1 t2
+          $ upperBoundsClosure t1 t2
+          $ atomicSubUpdate t1 t2
+          $ ctx0
 
+data FinalizerState =
+  FinalizerState
+  { -- | Type variables yet to be solved.
+    fsRemaining :: Set TyVar,
+    -- | Variables currently having their types resolved.
+    fsWorkingSet :: Set TyVar,
+    -- | Variables solved for already.
+    fsSolutions :: Map TyVar (Ty, Ty)
+  }
 
--- | @finalizeBounds dflt initMap@ removes all type variables from @initMap@ by
--- replacing them with their own bound from the same respective map (e.g.,
--- `B^{↑}` or `B^{↓}`). @dflt@ is used if no bound is found.
-  --
--- E.g., if `B^{↑} = {x → (Ptr y), y → int32}`, then the result would yield
--- `B^{↑} = {x → (Ptr int32), y → int32}`. IMPORTANT NOTE: this relies on their
--- not being cycles in the bounds map!
-finalizeBounds :: Ty -> Map TyVar Ty -> Map TyVar Ty
-finalizeBounds dflt initMap = Map.fromList $ LazyMap.toList finalLazyMap
-  where finalLazyMap =
-          -- Using a lazy map intentionally to let the ordering of dependencies
-          -- work itself out (since we're already checking for cycles in each <:
-          -- constraint).
-          LazyMap.fromList
-            $ map (\(x, xTy) -> (x, concretize xTy lookupVar))
-            $ Map.toList initMap
-        lookupVar x = LazyMap.findWithDefault dflt x finalLazyMap
+-- | @finalizeBounds ctx fvs@ computes the bounds closure in the given context,
+-- producing the final upper (`B^{↑}`) and lower (`B^{↓}`) bounds for variables
+-- in @fvs@.
+finalizeBounds :: Context -> Set TyVar -> Map TyVar (Ty, Ty)
+finalizeBounds ctx vars = fsSolutions $ execState solveVars (FinalizerState vars Set.empty Map.empty)
+  where solveVars :: State FinalizerState ()
+        solveVars = Set.lookupMin <$> gets fsRemaining >>= \case
+           Nothing -> pure ()
+           Just x -> do
+             modify' $ \s -> s{fsRemaining= Set.deleteMin $ fsRemaining s}
+             solveVar x
+             solveVars
+        solveVar :: TyVar -> State FinalizerState ()
+        solveVar x = do
+          xHasLoop <- Set.member x <$> gets fsWorkingSet
+          when xHasLoop $
+            error $ "Internal type unification error: The type of "
+                    ++ (show $ PP.pretty x) ++ " depends on itself in the current context, i.e.\n"
+                    ++ (show $ PP.pretty ctx)
+          modify' $ \s -> s{fsWorkingSet = Set.insert x $ fsWorkingSet s}
+          let (initL, initU) = naiveLookupBounds x
+          finalL <- concretizeM initL getLType
+          finalU <- concretizeM initU getUType
+          modify' $ \s -> s{fsSolutions = Map.insert x (finalL, finalU) $ fsSolutions s}
+          modify' $ \s -> s{fsWorkingSet = Set.delete x $ fsWorkingSet s}
+        -- | Get the lower bound for the type variable.
+        getLType :: TyVar -> State FinalizerState Ty
+        getLType x = do
+          solveVar x
+          fst <$> Map.findWithDefault (BotTy, TopTy) x <$> gets fsSolutions
+        -- Get the upper bound for the type variable.
+        getUType :: TyVar -> State FinalizerState Ty
+        getUType x = do
+          solveVar x
+          snd <$> Map.findWithDefault (BotTy, TopTy) x <$> gets fsSolutions
+        -- | Lookup the bounds of a type variable but "naively", in the sense we
+        -- do no concretization or other operations.
+        naiveLookupBounds :: TyVar -> (Ty, Ty)
+        naiveLookupBounds x = case Map.lookup x (ctxVarEqMap ctx) of
+                                Nothing -> Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap ctx)
+                                Just t -> (t,t)
 
---  ctx { ctxVarUpperBoundMap = finalizeMap TopTy (ctxVarUpperBoundMap ctx)
---      , ctxVarLowerBoundMap = finalizeMap BotTy (ctxVarLowerBoundMap ctx)}
 
 newtype TyUnificationError = TyUnificationError String
 
 processAtomicConstraints :: Context -> Context
-processAtomicConstraints ctx =
+processAtomicConstraints ctx = traceContext "processAtomicConstraints" ctx $
   case dequeueEqC ctx of
-    Just (c, ctx') -> processAtomicConstraints $ solveEqC c ctx'
+    Just (ctx', c) -> processAtomicConstraints $ solveEqC ctx' c
     Nothing ->
       case dequeueSubC ctx of
-        Just (c, ctx') -> processAtomicConstraints $ solveSubC c ctx'
+        Just (ctx', c) -> processAtomicConstraints $ solveSubC ctx' c
         Nothing -> ctx
+
+-- | Reduce a constraint given the context.
+reduceC :: Context -> TyConstraint -> TyConstraint
+reduceC ctx = go
+  where
+    go :: TyConstraint -> TyConstraint
+    go =
+      \case
+        TopC -> TopC
+        BotC -> BotC
+        c@(EqC s t) -> if absurdEqC ctx s t then BotC
+                      else if trivialEqC ctx s t then TopC
+                      else c
+        c@(SubC s t) -> if absurdSubC ctx s t then BotC
+                        else if trivialEqC ctx s t then TopC
+                        else c
+        OrC c1 c2 cs -> orC $ map go $ c1:c2:cs
+        AndC c1 c2 cs -> andC $ map go $ c1:c2:cs
+
+-- | Attempt to reduce and eliminate disjunctions in the given context. Any
+-- resulting non-disjuncts are added to their respective field in the context.
+reduceDisjuncts :: Context -> Context
+reduceDisjuncts initialContext = traceContext "reduceDisjuncts" initialContext $
+  let disjs = ctxOrConstraints initialContext
+      ctx0 = initialContext{ctxOrConstraints = []}
+   in foldr elim ctx0 disjs
+  where elim ::  [TyConstraint] -> Context -> Context
+        elim ds ctx = case orC $ map (reduceC ctx) ds of
+                       TopC -> ctx
+                       BotC -> ctx{ctxAbsurdConstraints = BotC:ctxAbsurdConstraints ctx}
+                       EqC s t -> ctx{ctxEqConstraints = (s,t):ctxEqConstraints ctx}
+                       SubC s t -> ctx{ctxSubConstraints = (s,t):ctxSubConstraints ctx}
+                       OrC c1 c2 cs -> ctx{ctxOrConstraints = (c1:c2:cs):ctxOrConstraints ctx}
+                       AndC c1 c2 cs -> addConstraints (c1:c2:cs) ctx
+
+-- | Reduce a context by processing its atomic constraints and then attempting
+-- to reduce disjucts to atomic constraints.
+reduceContext :: Context -> Context
+reduceContext ctx0 = -- traceContext "reduceContext" ctx0 $
+  let ctx1 = reduceDisjuncts $ processAtomicConstraints ctx0
+    in if hasAtomicConstraints ctx1 then reduceContext ctx1
+       else ctx1
 
 
 -- | Unify the given constraints, returning a conservative type map for all type
 -- variables.
-unifyConstraints :: [TyConstraint] -> Either TyUnificationError (Map TyVar Ty)
-unifyConstraints initialConstraints = undefined -- FIXME
+unifyConstraints :: [TyConstraint] -> Map TyVar Ty
+unifyConstraints initialConstraints =
+  let freeVars = foldr Set.union Set.empty $ map cFreeVars initialConstraints
+      finalCtx = reduceContext $ initContext initialConstraints
+      -- FIXME ^ this reduced context has not taken into account information still
+      -- nested in disjucts (cf. § 6.3.4 in TIE). At some point we likely will
+      -- want to do this... but we can soundly skip it for now.
+      boundsMap = finalizeBounds finalCtx freeVars
+      chooseBound (t1,t2) = if uninhabited t1 then t2 else t1
+    in fmap chooseBound boundsMap

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -1,20 +1,29 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- Loosely based on 'TIE: Principled Reverse Engineering of Types in Binary
 -- Programs' (NDSS 2011) by Jonghyup Lee, Thanassis Avgerinos, and David Brumley
 
 -- Not clear yet how much will directly be applicable etc.
 module Reopt.TypeInference.Constraints where
 
+
+import Data.Text (Text)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Map.Lazy as LazyMap
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Prettyprinter as PP
 -- import Data.List.NonEmpty (NonEmpty)
 -- import qualified Data.List.NonEmpty as NonEmpty
 
+import Debug.Trace ( trace )
 
 newtype TyVar = TyVar {tyVarInt :: Int }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
+
+instance PP.Pretty TyVar where
+  pretty (TyVar n) = "α" <> (PP.pretty n)
 
 -- | Types of values in x86 machine code (missing reg types, records/memory, functions)
 data Ty
@@ -44,8 +53,24 @@ data Ty
     AndTy Ty Ty [Ty]
   | -- | Union of two or more types. Should not contain duplicates or nested unions.
     OrTy Ty Ty [Ty]
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
+instance PP.Pretty Ty where
+  pretty = \case
+    TopTy -> "⊤"
+    BotTy -> "⊥"
+    VarTy tv -> PP.pretty tv
+    PtrTy n ty -> PP.parens $ "ptr" <> (PP.pretty n) PP.<+> PP.pretty ty
+    CodeTy n -> "code" <> (PP.pretty n) <> "_t"
+    RegTy n -> "reg"<>(PP.pretty n)<>"_t"
+    NumTy n -> "num"<>(PP.pretty n)<>"_t"
+    UIntTy n -> "uint"<>(PP.pretty n)<>"_t"
+    IntTy n -> "int"<>(PP.pretty n)<>"_t"
+    FloatTy n -> "float"<>(PP.pretty n)<>"_t"
+    AndTy ty1 ty2 tys -> PP.parens $ "∩" PP.<+> PP.hsep (map PP.pretty (ty1:ty2:tys))
+    OrTy ty1 ty2 tys ->  PP.parens $ "∪" PP.<+> PP.hsep (map PP.pretty (ty1:ty2:tys))
+
+-- | Is this a base type? I.e., a type that can fit in a single register.
 isBaseTy :: Ty -> Bool
 isBaseTy t = case t of
   TopTy -> False
@@ -141,6 +166,7 @@ concretize initialTy lookupVar = go initialTy
     go (AndTy t1 t2 ts) = andTy $ (go t1):(go t2):(map go ts)
     go (OrTy t1 t2 ts) = orTy $ (go t1):(go t2):(map go ts)
 
+
 -- | @subst x t1 t2@ says substitute appearances of @x@ out for @t1@ in @t2@.
 subst :: TyVar -> Ty -> Ty -> Ty
 subst x xTy ty = concretize ty (\y -> if x == y then xTy else (VarTy y))
@@ -185,8 +211,8 @@ upperBound type1 type2 =
     case (type1,type2) of
     (s,t) | s == t -> s
     -- J-Subtype
-    (s, t) | isBaseTy s && isBaseTy t && subtype s t -> t
-    (s, t) | isBaseTy s && isBaseTy t && subtype t s -> s
+    (s, t) | subtype s t -> t
+    (s, t) | subtype t s -> s
     -- J-TypeVar
     (s@(VarTy _), t) -> orTy [s,t]
     (s, t@(VarTy _)) -> orTy [s,t]
@@ -202,8 +228,8 @@ lowerBound type1 type2 =
   case (type1,type2) of
     (s,t) | s == t -> s
     -- M-Subtype
-    (s, t) | isBaseTy s && isBaseTy t && subtype s t -> s
-    (s, t) | isBaseTy s && isBaseTy t && subtype t s -> t
+    (s, t) | subtype s t -> s
+    (s, t) | subtype t s -> t
     -- M-TypeVar
     (s@(VarTy _), t) -> andTy [s,t]
     (s, t@(VarTy _)) -> andTy [s,t]
@@ -215,18 +241,18 @@ lowerBound type1 type2 =
 tyFreeVars :: Ty -> Set TyVar
 tyFreeVars =
     \case
-       TopTy -> Set.empty
-       BotTy -> Set.empty
-       VarTy x -> Set.singleton x
-       PtrTy _ t -> tyFreeVars t
-       CodeTy{} -> Set.empty
-       RegTy{} -> Set.empty
-       NumTy{} -> Set.empty
-       IntTy{} -> Set.empty
-       UIntTy{} -> Set.empty
-       FloatTy{} -> Set.empty
-       (AndTy t1 t2 ts) -> foldl Set.union (tyFreeVars t1) (map tyFreeVars $ t2:ts)
-       (OrTy t1 t2 ts)  -> foldl Set.union (tyFreeVars t1) (map tyFreeVars $ t2:ts)
+      TopTy -> Set.empty
+      BotTy -> Set.empty
+      VarTy x -> Set.singleton x
+      PtrTy _ t -> tyFreeVars t
+      CodeTy{} -> Set.empty
+      RegTy{} -> Set.empty
+      NumTy{} -> Set.empty
+      IntTy{} -> Set.empty
+      UIntTy{} -> Set.empty
+      FloatTy{} -> Set.empty
+      (AndTy t1 t2 ts) -> foldl Set.union (tyFreeVars t1) (map tyFreeVars $ t2:ts)
+      (OrTy t1 t2 ts)  -> foldl Set.union (tyFreeVars t1) (map tyFreeVars $ t2:ts)
 
 -- | @occursIn x t@, does `x` appear in `t`?
 occursIn :: TyVar -> Ty -> Bool
@@ -238,12 +264,42 @@ data TyConstraint
     EqC Ty Ty
   | -- | A subtype constraint.
     SubC Ty Ty
-  | OrC [TyConstraint]
-  | AndC [TyConstraint]
+  | OrC  TyConstraint TyConstraint [TyConstraint]
+  | AndC TyConstraint TyConstraint [TyConstraint]
+  deriving (Eq, Ord, Show)
 
--- eqConstraint :: Ty -> Ty -> TyConstraint
--- eqConstraint
+instance PP.Pretty TyConstraint where
+  pretty (EqC l r) = (PP.pretty l) PP.<+> "=" PP.<+> (PP.pretty r)
+  pretty (SubC l r) = (PP.pretty l) PP.<+> "<:" PP.<+> (PP.pretty r)
+  pretty (OrC c1 c2 cs) = PP.parens $ PP.hsep $ "or":(map (\c -> PP.parens $ PP.pretty c) (c1:c2:cs))
+  pretty (AndC c1 c2 cs) = PP.parens $ PP.hsep $ "and":(map (\c -> PP.parens $ PP.pretty c) (c1:c2:cs))
 
+-- Constructs a conjunction constraint, simplifying some basic cases.
+andC :: [TyConstraint] -> TyConstraint
+andC = go Set.empty
+  where go :: Set TyConstraint -> [TyConstraint] -> TyConstraint
+        go acc [] = case Set.toAscList acc of
+                      [] -> EqC TopTy TopTy
+                      [c] -> c
+                      c1:c2:cs -> AndC c1 c2 cs
+        go acc (c@EqC{}:cs) = go (Set.insert c acc) cs
+        go acc (c@SubC{}:cs) = go (Set.insert c acc) cs
+        go acc (AndC c1 c2 cs:cs') = go acc (c1:c2:(cs++cs'))
+        go acc (c@OrC{}:cs) = go (Set.insert c acc) cs
+
+
+-- Constructs a disjunction constraint, simplifying some basic cases.
+orC :: [TyConstraint] -> TyConstraint
+orC = go Set.empty
+  where go :: Set TyConstraint -> [TyConstraint] -> TyConstraint
+        go acc [] = case Set.toAscList acc of
+                      [] -> EqC BotTy TopTy
+                      [c] -> c
+                      c1:c2:cs -> OrC c1 c2 cs
+        go acc (c@EqC{}:cs) = go (Set.insert c acc) cs
+        go acc (c@SubC{}:cs) = go (Set.insert c acc) cs
+        go acc (OrC c1 c2 cs:cs') = go acc (c1:c2:(cs++cs'))
+        go acc (c@AndC{}:cs) = go (Set.insert c acc) cs
 
 -- cSubst :: TyVar -> Ty -> TyConstraint -> TyConstraint
 -- cSubst x xTy constraint = go constraint
@@ -272,24 +328,53 @@ data Context
   = Context
     { -- | Equality constraints, i.e. each `(s,t)` means `s == t`. Cf. `C` from TIE § 6.3.
       ctxEqConstraints  :: [(Ty, Ty)]
+      -- | Equality constraints that were dropped.
+    , ctxDroppedEqConstraints :: [(Ty, Ty)]
+      -- | Occurs check failures.
+    , ctxOccursCheckFailures :: [(Ty, Ty)]
     , -- | Subtype constraints, i.e. each `(s,t)` means `s <: t`. Cf. `C` from TIE § 6.3.
       ctxSubConstraints :: [(Ty, Ty)]
     , -- | Disjunctive constraints, i.e. each `[c1,c2,...]` means `c1 ∨ c2 ∨ ...`. Cf. `C` from TIE § 6.3.
       ctxOrConstraints  :: [[TyConstraint]]
-      -- | Map from type variables to their known subtypes.
-      -- One half of `S_{<:}` from TIE § 6.3.
-    , ctxSubtypeMap :: Map TyVar (Set Ty)
-      -- | Map from type variables to their known supertypes.
-      -- One half of `S_{<:}` from TIE § 6.3.
-    , ctxSupertypeMap :: Map TyVar (Set Ty)
+      -- | Map from type variables to their known subtypes and supertypes.
+      -- Cf.`S_{<:}` from TIE § 6.3.
+    , ctxSubtypeMap :: Map TyVar (Set Ty, Set Ty)
     -- | Known type for type variables. `S_{=}` from TIE § 6.3. N.B., this map
     -- is used in conjunction with `substEqs` to apply substitutions lazily.
     , ctxVarTypeMap :: Map TyVar Ty
-    -- | Upper bounds for type variables. `B^{↑}` from TIE § 6.3.
-    , ctxVarUpperBoundMap :: Map TyVar Ty
-    -- | Lower bounds for type variables. `B^{↓}` from TIE § 6.3.
-    , ctxVarLowerBoundMap :: Map TyVar Ty
+    -- | Lower and upper bounds for type variables. `B^{↓}` and `B^{↑}` from TIE § 6.3.
+    , ctxVarBoundsMap :: Map TyVar (Ty, Ty)
     }
+  deriving (Eq, Ord, Show)
+
+instance PP.Pretty Context where
+  pretty ctx = let binop op (l,r) = (PP.pretty l) PP.<+> op PP.<+> (PP.pretty r)
+                   row title entries = title PP.<+> PP.list entries in
+                  PP.vsep
+                  [ row "Equalities" $ map (binop "=") $ ctxEqConstraints ctx
+                  , row "Dropped Equalities" $ map (binop "=") $ ctxDroppedEqConstraints ctx
+                  , row "Occurs check failures" $ map (binop "=") $ ctxOccursCheckFailures ctx
+                  , row "Subtypes" $ map (binop "<:") $ ctxSubConstraints ctx
+                  , row "Ors" $ map (\cs -> PP.list $ map PP.pretty cs) $ ctxOrConstraints ctx
+                  , row "S_{<:}" $ map (\(x,(ls,us)) -> (PP.encloseSep "{" "}" "," $ map PP.pretty $ Set.toList ls)
+                                                      PP.<+> "<:" PP.<+> PP.pretty x PP.<+> "<:"
+                                                      PP.<+> (PP.encloseSep "{" "}" "," $ map PP.pretty $ Set.toList us))
+                                 $ Map.toList $ ctxSubtypeMap ctx
+                  , row "S_{=}" $ map (binop "↦") $ Map.toList $ ctxVarTypeMap ctx
+                  , row "B^{↓}/B^{↑}" $ map (\(x,(l,u)) -> PP.pretty l PP.<+> "<:" PP.<+> PP.pretty x PP.<+> "<:" PP.<+> PP.pretty u)
+                                      $ Map.toList $ ctxVarBoundsMap ctx
+                  ]
+
+dequeueEqC :: Context -> Maybe ((Ty,Ty), Context)
+dequeueEqC ctx = case ctxEqConstraints ctx of
+                  [] -> Nothing
+                  c:cs -> Just (c,ctx{ctxEqConstraints=cs})
+
+dequeueSubC :: Context -> Maybe ((Ty,Ty), Context)
+dequeueSubC ctx = case ctxSubConstraints ctx of
+                   [] -> Nothing
+                   c:cs -> Just (c,ctx{ctxSubConstraints=cs})
+
 
 addConstraints :: [TyConstraint] -> Context -> Context
 addConstraints [] ctx = ctx
@@ -297,10 +382,10 @@ addConstraints ((EqC  t1 t2):cs) ctx =
     addConstraints cs (ctx {ctxEqConstraints = (t1,t2):ctxEqConstraints ctx})
 addConstraints ((SubC t1 t2):cs) ctx =
   addConstraints cs (ctx {ctxSubConstraints = (t1,t2):ctxSubConstraints ctx})
-addConstraints ((OrC cs'):cs) ctx =
-    addConstraints cs (ctx {ctxOrConstraints = cs':ctxOrConstraints ctx})
-addConstraints ((AndC cs'):cs) ctx =
-    addConstraints (cs'++cs) ctx
+addConstraints ((OrC c1 c2 cs'):cs) ctx =
+    addConstraints cs (ctx {ctxOrConstraints = (c1:c2:cs'):ctxOrConstraints ctx})
+addConstraints ((AndC c1 c2 cs'):cs) ctx =
+    addConstraints (c1:c2:cs'++cs) ctx
 
 
 -- | Perform the substitutions implied thus far by the @Context@'s
@@ -313,15 +398,15 @@ substEqs t cinfo = concretize t lookupVar
 -- | Concretize the type using any available upper bounds for type variables.
 currentUpperBound :: Ty -> Context -> Ty
 currentUpperBound t cinfo = concretize t lookupVar
-  where lookupVar x = Map.findWithDefault TopTy x (ctxVarUpperBoundMap cinfo)
+  where lookupVar x = snd $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap cinfo)
 
 -- | Concretize the type using any available lower bounds for type variables.
 currentLowerBound :: Ty -> Context -> Ty
 currentLowerBound t cinfo = concretize t lookupVar
-  where lookupVar x = Map.findWithDefault BotTy x (ctxVarLowerBoundMap cinfo)
+  where lookupVar x = fst $ Map.findWithDefault (BotTy, TopTy) x (ctxVarBoundsMap cinfo)
 
 emptyContext :: Context
-emptyContext = Context [] [] [] Map.empty Map.empty Map.empty Map.empty Map.empty
+emptyContext = Context [] [] [] [] [] Map.empty Map.empty Map.empty
 
 -- | Partition the constraints into the @Context@, which we use to order
 -- which are handled when during unification.
@@ -331,104 +416,169 @@ initContext constraints = addConstraints constraints emptyContext
 -- FIXME use S_{=} to not actually do full substitutions all the time and just
 -- do them _as_ we consider constraints...? Use a newtype?
 
+-- | @traceContext description ctx ctx'@ reports how the context changed via @trace@.
+traceContext :: PP.Doc () -> Context -> Context -> Context
+traceContext description preCtx postCtx =
+  let msg = PP.vsep [PP.hsep [">>> ", description]
+                    , PP.indent 4 $ PP.pretty preCtx
+                    , PP.hsep ["<<< ", description]
+                    , PP.indent 4 $ PP.pretty postCtx]
+    in trace (show msg) postCtx
+
+
 -- | @solveEqC (s,t) ctx@ updates @ctx@ with the equality
 -- `s == t`. Cf. TIE Algorithm 1. If @Nothing@ is returned, the equality
 -- failed the occurs check. FIXME should we have a `decomposeEqC` similar to `decomposeSubC`?
-solveEqC :: (Ty,Ty) -> Context -> Maybe Context
-solveEqC (type1, type2) ctx = go (substEqs type1 ctx) (substEqs type2 ctx)
-  where go :: Ty -> Ty -> Maybe Context
-        go (VarTy x) t =
+solveEqC :: (Ty,Ty) -> Context -> Context
+solveEqC (type1, type2) ctx =
+  traceContext ("solveEqC(" <> (PP.pretty $ EqC type1 type2)<> ")")
+  ctx
+  $ go (substEqs type1 ctx) (substEqs type2 ctx)
+  where go :: Ty -> Ty -> Context
+        go s@(VarTy x) t =
           if occursIn x t
-            then Nothing
-            else Just $ ctx{ctxVarTypeMap = Map.insert x t (ctxVarTypeMap ctx)}
+            then ctx{ctxOccursCheckFailures=(s,t):(ctxOccursCheckFailures ctx)}
+            else ctx{ctxVarTypeMap = Map.insert x t (ctxVarTypeMap ctx)}
         go s t@(VarTy _) = go t s
-        go (PtrTy _w1 s) (PtrTy _w2 t) = Just $ ctx {ctxEqConstraints = (s,t):ctxEqConstraints ctx}
-        go _ _ = Just ctx
+        go (PtrTy _w1 s) (PtrTy _w2 t) = ctx {ctxEqConstraints = (s,t):ctxEqConstraints ctx}
+        go s t = ctx{ctxDroppedEqConstraints= (s,t):(ctxDroppedEqConstraints ctx)}
 
 
--- | Given `s <: t`, for all type variables `α` where `α <: s`, we add `α <: t`,
--- update the upper bound of `α`, and record any implied information from `α <:
--- s`. Cf. rule (2) in the Decomposition Rules of § 6.3.2. N.B., we interpret
--- the `S <: T` constraint described by TIE to include any `S` and `T`, but for
--- `∀(α <: S)` to quantify only over known subtype constraints where `α` is
--- _explicitly a type variable_.
-updateUpperBounds :: (Ty, Ty) -> Context -> Context
-updateUpperBounds (s, t) initial =
+-- | @upperBoundsClosure s t ctx@ says given `s <: t`, for all type variables
+-- `α` where `α <: s`, we add `α <: t`, update the upper bound of `α`, and
+-- record any implied information from `α <: s`. Cf. rule (2) in the
+-- Decomposition Rules of § 6.3.2. N.B., we interpret the `S <: T` constraint
+-- described by TIE to include any `S` and `T`, but for `∀(α <: S)` to quantify
+-- only over known subtype constraints where `α` is _explicitly a type
+-- variable_.
+upperBoundsClosure :: Ty -> Ty -> Context -> Context
+upperBoundsClosure s t initial =
   -- Find all `α` where `α <: s` and perform updates to propogate `α <: t`.
-  Map.foldrWithKey update initial (ctxSupertypeMap initial)
+  Map.foldrWithKey update initial (ctxSubtypeMap initial)
   where
-    update :: TyVar -> Set Ty -> Context -> Context
-    update a ts ctx =
+    update :: TyVar -> (Set Ty, Set Ty) -> Context -> Context
+    update a (lowerBounds,upperBounds) ctx =
       -- If `α </: s` or if we _already_ know `α <: t` then simply move on.
-      if not (Set.member s ts) || (Set.member t ts) then ctx
+      if not (Set.member s upperBounds) || (Set.member t upperBounds) then ctx
       -- otherwise we need to compute the closure
       else
         let -- `S_{<:} = S_{<:} ∪ {a <: t}`
-            supMap' = let updateSupSet mTys =
-                              case mTys of Nothing  -> Just $ Set.singleton t
-                                           Just tys -> Just $ Set.insert t tys
-                        in Map.alter updateSupSet a $ ctxSupertypeMap ctx
+            supMap' = Map.insert a (lowerBounds, Set.insert t upperBounds) $ ctxSubtypeMap ctx
             -- `B↑(α) ← B↑(α) ⊓ B↑(T)`
-            upperMap' = let aTy = lowerBound (currentUpperBound (VarTy a) ctx) (currentUpperBound t ctx)
-                          in Map.insert a aTy $ ctxVarUpperBoundMap ctx
+            boundsMap' = let aLower = fst $ Map.findWithDefault (BotTy, TopTy) a $ ctxVarBoundsMap ctx
+                             aUpper = lowerBound (currentUpperBound (VarTy a) ctx) (currentUpperBound t ctx)
+                          in Map.insert a (aLower, aUpper) $ ctxVarBoundsMap ctx
           in -- Add `Υ(α <: T)` to `C`. (N.B., TIE suggests adding `Υ(α <: S)`
              -- instead, but if we previously recorded `α <: S` already, then we
              -- would have already recorded `Υ(α <: S)` at that time as well).
              addConstraints (decomposeSubC (VarTy a) t)
-             $ ctx { ctxSupertypeMap = supMap',
-                     ctxVarUpperBoundMap = upperMap'}
+             $ ctx { ctxSubtypeMap = supMap',
+                     ctxVarBoundsMap = boundsMap'}
 
--- | Given `s <: t`, for all type variables `β` where `t <: β`, we add `s <: β`,
--- update the lower bound of `β`, and record any implied information from `s <:
--- β`. Cf. rule (3) in the Decomposition Rules of § 6.3.2. N.B., we interpret
--- the `S <: T` constraint described by TIE to include any `S` and `T`, but for
--- `∀(T <: α)` to quantify only over known subtype constraints where `β` is
--- _explicitly a type variable_.
-updateLowerBounds :: (Ty, Ty) -> Context -> Context
-updateLowerBounds (s, t) initial =
+-- | @lowerBoundsClosure s t ctx@ says given `s <: t`, for all type variables
+-- `β` where `t <: β`, we add `s <: β`, update the lower bound of `β`, and
+-- record any implied information from `s <: β`. Cf. rule (3) in the
+-- Decomposition Rules of § 6.3.2. N.B., we interpret the `S <: T` constraint
+-- described by TIE to include any `S` and `T`, but for `∀(T <: α)` to quantify
+-- only over known subtype constraints where `β` is _explicitly a type
+-- variable_.
+lowerBoundsClosure :: Ty -> Ty -> Context -> Context
+lowerBoundsClosure s t initial =
   -- Find all `β` where `t <: β` and perform updates to propogate `s <: β`.
   Map.foldrWithKey update initial (ctxSubtypeMap initial)
   where
-    update :: TyVar -> Set Ty -> Context -> Context
-    update b ts ctx =
+    update :: TyVar -> (Set Ty, Set Ty) -> Context -> Context
+    update b (lowerBounds,upperBounds) ctx =
       -- If `t </: β` or if we _already_ know `s <: β` then simply move on.
-      if not (Set.member t ts) || (Set.member s ts) then ctx
+      if not (Set.member t lowerBounds) || (Set.member s lowerBounds) then ctx
       -- otherwise we need to compute the closure
       else
         -- Add `Υ(S <: β)` to `C`. (N.B., TIE suggests adding `Υ(T <: β)`
         -- instead, but if we previously recorded `T <: β` already, then we
         -- would have already recorded `Υ(T <: β)` at that time as well).
         let -- `S_{<:} = S_{<:} ∪ {s <: β}`
-            subMap' = let updateSubSet mTys =
-                              case mTys of Nothing  -> Just $ Set.singleton s
-                                           Just tys -> Just $ Set.insert s tys
-                        in Map.alter updateSubSet b $ ctxSubtypeMap ctx
+            subMap' = Map.insert b (Set.insert s lowerBounds,upperBounds) $ ctxSubtypeMap ctx
             -- `B↓(α) ← B↓(β) ⊔ B↓(S)`
-            lowerMap' = let bTy = upperBound (currentLowerBound (VarTy b) ctx) (currentLowerBound s ctx)
-                          in Map.insert b bTy $ ctxVarLowerBoundMap ctx
+            boundsMap' = let bLower = upperBound (currentLowerBound (VarTy b) ctx) (currentLowerBound s ctx)
+                             bUpper = snd $ Map.findWithDefault (BotTy, TopTy) b $ ctxVarBoundsMap ctx
+                          in Map.insert b (bLower, bUpper) $ ctxVarBoundsMap ctx
           in addConstraints (decomposeSubC s (VarTy b))
              $ ctx { ctxSubtypeMap = subMap',
-                     ctxVarUpperBoundMap = lowerMap'}
+                     ctxVarBoundsMap = boundsMap'}
 
--- FIXME use `decomposeSubC` as a "preprocess" pass over the subtype constraint...???
+-- | @atomicSubUpdate s t ctx@ records the basic information relevant for `s <:
+-- t` (i.e., it does not compute the closure).
+atomicSubUpdate :: Ty -> Ty -> Context -> Context
+atomicSubUpdate type1 type2 = (updateLower type1 type2) . (updateUpper type1 type2)
+  where updateLower s (VarTy x) ctx =
+          let sMap = ctxSubtypeMap ctx
+              (lSet, uSet) = Map.findWithDefault (Set.empty, Set.empty) x sMap
+              bMap = ctxVarBoundsMap ctx
+              (lBound, uBound) = Map.findWithDefault (BotTy, TopTy) x bMap
+              lBound' = upperBound (currentLowerBound lBound ctx) (currentLowerBound s ctx)
+            in ctx { ctxSubtypeMap = Map.insert x (Set.insert s lSet, uSet) sMap
+                   , ctxVarBoundsMap = Map.insert x (lBound', uBound) bMap}
+        updateLower _ _ ctx = ctx
+        updateUpper (VarTy x) t ctx =
+          let sMap = ctxSubtypeMap ctx
+              (lSet, uSet) = Map.findWithDefault (Set.empty, Set.empty) x sMap
+              bMap = ctxVarBoundsMap ctx
+              (lBound, uBound) = Map.findWithDefault (BotTy, TopTy) x bMap
+              uBound' = lowerBound (currentUpperBound uBound ctx) (currentUpperBound t ctx)
+            in ctx { ctxSubtypeMap = Map.insert x (Set.insert t lSet, uSet) sMap
+                   , ctxVarBoundsMap = Map.insert x (lBound, uBound') bMap}
+        updateUpper _ _ ctx = ctx
 
 -- | @solveSubC (t1,t2) cset cinfo@ updates @cset@ and @cinfo@ with the subtype constraint
 -- `t1 <: t2`. Cf. TIE § 6.3.2.
 solveSubC :: (Ty,Ty) -> Context -> Context
-solveSubC (type1,type2) ctx =
+solveSubC (type1,type2) ctx = traceContext ("solveSubC(" <> (PP.pretty $ SubC type1 type2)<> ")") ctx $
   let t1 = substEqs type1 ctx
       t2 = substEqs type2 ctx
   in -- cycle check
      if not $ Set.disjoint (tyFreeVars t1) (tyFreeVars t2) then ctx
      -- If `t1 <: t2` the contraint is trivial and should be discarded.
      else if subtype t1 t2 then ctx
+     -- FIXME What if `t1 <: t2` is unsatisfiable? probably should stop and
+     -- record that or similar instead of all the follow on computation.
      else addConstraints (decomposeSubC t1 t2)
-           $ updateLowerBounds (t1,t2)
-           $ updateUpperBounds (t1,t2)
+           $ lowerBoundsClosure t1 t2
+           $ upperBoundsClosure t1 t2
+           $ atomicSubUpdate t1 t2
            $ ctx
 
 
+-- | @finalizeBounds dflt initMap@ removes all type variables from @initMap@ by
+-- replacing them with their own bound from the same respective map (e.g.,
+-- `B^{↑}` or `B^{↓}`). @dflt@ is used if no bound is found.
+  --
+-- E.g., if `B^{↑} = {x → (Ptr y), y → int32}`, then the result would yield
+-- `B^{↑} = {x → (Ptr int32), y → int32}`. IMPORTANT NOTE: this relies on their
+-- not being cycles in the bounds map!
+finalizeBounds :: Ty -> Map TyVar Ty -> Map TyVar Ty
+finalizeBounds dflt initMap = Map.fromList $ LazyMap.toList finalLazyMap
+  where finalLazyMap =
+          -- Using a lazy map intentionally to let the ordering of dependencies
+          -- work itself out (since we're already checking for cycles in each <:
+          -- constraint).
+          LazyMap.fromList
+            $ map (\(x, xTy) -> (x, concretize xTy lookupVar))
+            $ Map.toList initMap
+        lookupVar x = LazyMap.findWithDefault dflt x finalLazyMap
+
+--  ctx { ctxVarUpperBoundMap = finalizeMap TopTy (ctxVarUpperBoundMap ctx)
+--      , ctxVarLowerBoundMap = finalizeMap BotTy (ctxVarLowerBoundMap ctx)}
+
 newtype TyUnificationError = TyUnificationError String
+
+processAtomicConstraints :: Context -> Context
+processAtomicConstraints ctx =
+  case dequeueEqC ctx of
+    Just (c, ctx') -> processAtomicConstraints $ solveEqC c ctx'
+    Nothing ->
+      case dequeueSubC ctx of
+        Just (c, ctx') -> processAtomicConstraints $ solveSubC c ctx'
+        Nothing -> ctx
 
 
 -- | Unify the given constraints, returning a conservative type map for all type

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -129,7 +129,7 @@ upperBound type1 type2 =
     -- J-TypeVar
     (t1@(VarTy _), t2) -> orTy t1 t2
     (t1, t2@(VarTy _)) -> orTy t1 t2
-    -- J-Ptr
+    -- J-Ptr (N.B., TIE uses ⊓ in this rule, but I think that's a typo)
     ((PtrTy t1), (PtrTy t2)) -> ptrTy (upperBound t1 t2)
     -- J-NoRel
     (_,_) -> TopTy
@@ -316,8 +316,11 @@ updateUpperBounds (s, t) initial =
       -- If `α </: s` or if we _already_ know `α <: t` then simply move on.
       if not (Set.member s ts) || (Set.member t ts) then (cset, cinfo)
       -- otherwise we need to compute the closure
-      else  -- Add `Υ(α <: S)` to `C`.
-        let cset' = addConstraints (decomposeSubC (VarTy a) s) cset
+      else
+        -- Add `Υ(α <: T)` to `C`. (N.B., TIE suggests adding `Υ(α <: S)`
+        -- instead, but if we previously recorded `α <: S` already, then we
+        -- would have already recorded `Υ(α <: S)` at that time as well).
+        let cset' = addConstraints (decomposeSubC (VarTy a) t) cset
             -- `S_{<:} = S_{<:} ∪ {a <: t}`
             supCache' = let updateSupSet mTys =
                               case mTys of Nothing  -> Just $ Set.singleton t

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -1,0 +1,56 @@
+-- Loosely based on 'TIE: Principled Reverse Engineering of Types in Binary
+-- Programs' (NDSS 2011) by Jonghyup Lee, Thanassis Avgerinos, and David Brumley
+
+-- Not clear yet how much will directly be applicable etc.
+module Reopt.TypeInference.Constraints where
+
+
+
+data Ty
+  = TyData DataTy
+  | TyFun
+  | TyTop
+  | TyBot
+  | TyAnd Ty Ty
+  | TyOr Ty Ty
+  | TyArrow Ty Ty
+
+data DataTy
+  = DTyBase BaseTy
+  | DTyMem MemTy
+
+
+data BaseTy
+  = BTyBase RegTy
+  | BTyRefined RefinedTy
+
+-- | Maps each memory cell address to the type stored at that address.
+data MemTy = MemTy -- ??? {∀ addresses i|li : Ti } wut is that? a set of address/type mappings?
+
+
+
+-- | Register types, Cf. τ_reg
+data RegTy
+  = Reg1Ty
+  | Reg8Ty
+  | Reg16Ty
+  | Reg32Ty
+  | Reg64Ty
+
+
+-- | Refined types, Cf. τ_refined
+data RefinedTy
+  = Num8RTy
+  | Num16RTy
+  | Num32RTy
+  | Num64RTy
+  | UInt8RTy
+  | UInt16RTy
+  | UInt32RTy
+  | UInt64RTy
+  | Int8RTy
+  | Int16RTy
+  | Int32RTy
+  | Int64RTy
+  | PtrRTy Ty
+  | CodeRTy

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -285,11 +285,11 @@ initConstraintSet constraints = addConstraints constraints emptyConstraintSet
 -- FIXME use S_{=} to not actually do full substitutions all the time and just
 -- do them _as_ we consider constraints...? Use a newtype?
 
--- | @solveEqC (t1,t2) cset cinfo@ updates @cset@ and @cinfo@ with the equality
--- `t1 == t2`. Cf. TIE Algorithm 1. If @Nothing@ is returned, the equality
+-- | @solveEqC (s,t) cset cinfo@ updates @cset@ and @cinfo@ with the equality
+-- `s == t`. Cf. TIE Algorithm 1. If @Nothing@ is returned, the equality
 -- failed the occurs check.
 solveEqC :: (X86Ty,X86Ty) -> (ConstraintSet, ConstraintInfo) -> Maybe (ConstraintSet, ConstraintInfo)
-solveEqC (type1, type2) (cset, cinfo) = go type1 type2
+solveEqC (s, t) (cset, cinfo) = go s t
   where go :: X86Ty -> X86Ty -> Maybe (ConstraintSet, ConstraintInfo)
         go (VarTy x) t2 =
           if occursIn x t2

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -5,6 +5,10 @@
 -- Not clear yet how much will directly be applicable etc.
 module Reopt.TypeInference.Constraints where
 
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 data NumSize
   = NumSize8
@@ -12,28 +16,6 @@ data NumSize
   | NumSize32
   | NumSize64
   deriving (Eq, Ord)
-
-
-newtype TyVar = TyVar {tyVarInt :: Int }
-  deriving (Eq, Ord)
-
--- | Types of values in x86 machine code
-data X86Ty
-  = UnknownTy -- the top type
-  | AbsurdTy -- the bottom type
-  | VarTy TyVar -- a type unification variable
-  | PtrTy
-  | NumTy NumSize
-  | ScalarFloatTy
-  | VecFloatTy
-  deriving (Eq, Ord)
-
--- | x86 type constraints
-data X86TyConstraint
-  = -- | These types are known to be equal.
-    EqC X86Ty X86Ty
-  -- | These types were used in an addition operation of width @NumSize@.
-  | AddC NumSize X86Ty X86Ty
 
 numSizeInt :: NumSize -> Int
 numSizeInt =
@@ -43,25 +25,311 @@ numSizeInt =
     NumSize32 -> 32
     NumSize64 -> 64
 
--- | @subtype t1 t2@ returns @True@ iff @t1@ is a subtype of @t2@.
+newtype TyVar = TyVar {tyVarInt :: Int }
+  deriving (Eq, Ord)
+
+-- | Types of values in x86 machine code
+data X86Ty
+  = TopTy
+  | BotTy
+  | VarTy TyVar -- a type unification variable
+  | PtrTy X86Ty
+  | NumTy NumSize
+  | ScalarFloatTy
+  | VecFloatTy -- FIXME does this overlap with ScalarFloatTy in it's memory representation?
+  | AndTy X86Ty X86Ty
+  | OrTy X86Ty X86Ty
+  deriving (Eq, Ord)
+
+isBaseTy :: X86Ty -> Bool
+isBaseTy t =
+  case t of
+    PtrTy _ -> True
+    NumTy _ -> True
+    ScalarFloatTy -> True
+    VecFloatTy -> True
+    _ -> False
+
+
+num8Ty, num16Ty, num32Ty, num64Ty :: X86Ty
+num8Ty = NumTy NumSize8
+num16Ty = NumTy NumSize16
+num32Ty = NumTy NumSize32
+num64Ty = NumTy NumSize64
+
+-- Constructs a pointer type, simplifying some cases.
+ptrTy :: X86Ty -> X86Ty
+ptrTy BotTy = BotTy
+ptrTy t = PtrTy t
+
+-- Constructs an intersection type, simplifying some cases.
+andTy :: X86Ty -> X86Ty -> X86Ty
+andTy BotTy _ = BotTy
+andTy _ BotTy = BotTy
+andTy TopTy t = t
+andTy t TopTy = t
+andTy (PtrTy t1) (PtrTy t2) = PtrTy (andTy t1 t2)
+andTy t1 t2 = if t1 == t2 then t1 else AndTy t1 t2
+
+-- Constructs a union type, simplifying some cases.
+orTy :: X86Ty -> X86Ty -> X86Ty
+orTy BotTy t = t
+orTy t BotTy = t
+orTy TopTy _ = TopTy
+orTy _ TopTy = TopTy
+orTy t1 t2 = if t1 == t2 then t1 else OrTy t1 t2
+
+
+-- | Return the given type with all type variables replaced via the lookup function.
+concretize :: X86Ty -> (TyVar -> X86Ty) -> X86Ty
+concretize initialTy lookupVar = go initialTy
+  where
+    go :: X86Ty -> X86Ty
+    go TopTy = TopTy
+    go BotTy = BotTy
+    go (VarTy x) = lookupVar x
+    go (PtrTy t) = ptrTy (go t)
+    go t@(NumTy _) = t
+    go ScalarFloatTy = ScalarFloatTy
+    go VecFloatTy = VecFloatTy
+    go (AndTy t1 t2) = andTy (go t1) (go t2)
+    go (OrTy t1 t2) = orTy (go t1) (go t2)
+
+-- | @subst x t1 t2@ says substitute appearances of @x@ out for @t1@ in @t2@.
+subst :: TyVar -> X86Ty -> X86Ty -> X86Ty
+subst x xTy ty = concretize ty (\y -> if x == y then xTy else (VarTy y))
+
 subtype :: X86Ty -> X86Ty -> Bool
-subtype t1 t2 =
-  case (t1,t2) of
-    (_,_) | t1 == t2 -> True
-    (_, UnknownTy) -> True
-    (AbsurdTy, _) -> True
+subtype type1 type2 =
+  case (type1,type2) of
+    (t1,t2) | t1 == t2 -> True
+    (_, TopTy) -> True
+    (BotTy, _) -> True
+    (PtrTy t1, PtrTy t2) -> subtype t1 t2
     (NumTy n1, NumTy n2) -> (numSizeInt n1) <= (numSizeInt n2)
-    (_,_) -> False
+    (AndTy t1 t2, t3) -> subtype t1 t3 || subtype t2 t3
+    (OrTy t1 t2, t3)  -> subtype t1 t3 && subtype t2 t3
+    (t1, AndTy t2 t3) -> subtype t1 t2 && subtype t1 t3
+    (t1, OrTy t2 t3)  -> subtype t1 t2 || subtype t1 t3
+    (_, _) -> False
 
 
-
-
--- -- | Calculates the least upper bound of two types (denoted by the “join”
+-- | Calculates the (least) upper bound of two types (denoted by the “join”
 -- operator ⊔).
--- join :: Ty -> Ty -> Ty
--- join  = undefined -- FIXME
+upperBound :: X86Ty -> X86Ty -> X86Ty
+upperBound type1 type2 =
+    case (type1,type2) of
+    (t1,t2) | t1 == t2 -> t1
+    -- J-Subtype
+    (t1, t2) | isBaseTy t1 && isBaseTy t2 && subtype t1 t2 -> t2
+    (t1, t2) | isBaseTy t1 && isBaseTy t2 && subtype t2 t1 -> t1
+    -- J-TypeVar
+    (t1@(VarTy _), t2) -> OrTy t1 t2
+    (t1, t2@(VarTy _)) -> OrTy t1 t2
+    -- J-Ptr
+    ((PtrTy t1), (PtrTy t2)) -> PtrTy (upperBound t1 t2)
+    -- J-NoRel
+    (_,_) -> TopTy
 
--- -- | Calculates the greatest lower bound of two types (denoted by the meet”
--- -- operator ⊓).
--- meet :: Ty -> Ty -> Ty
--- meet  = undefined -- FIXME
+-- | Calculates the (greatest) lower bound of two types (denoted by the meet”
+-- operator ⊓).
+lowerBound :: X86Ty -> X86Ty -> X86Ty
+lowerBound type1 type2 =
+  case (type1,type2) of
+    (t1,t2) | t1 == t2 -> t1
+    -- M-Subtype
+    (t1, t2) | isBaseTy t1 && isBaseTy t2 && subtype t1 t2 -> t1
+    (t1, t2) | isBaseTy t1 && isBaseTy t2 && subtype t2 t1 -> t2
+    -- M-TypeVar
+    (t1@(VarTy _), t2) -> AndTy t1 t2
+    (t1, t2@(VarTy _)) -> AndTy t1 t2
+    -- M-Ptr
+    ((PtrTy t1), (PtrTy t2)) -> PtrTy (lowerBound t1 t2)
+    -- M-NoRel
+    (_,_) -> BotTy
+
+tyFreeVars :: X86Ty -> Set TyVar
+tyFreeVars =
+    \case
+       TopTy -> Set.empty
+       BotTy -> Set.empty
+       (VarTy x) -> Set.singleton x
+       (PtrTy t) -> tyFreeVars t
+       (NumTy _) -> Set.empty
+       ScalarFloatTy -> Set.empty
+       VecFloatTy -> Set.empty
+       (AndTy t1 t2) -> Set.union (tyFreeVars t1) (tyFreeVars t2)
+       (OrTy t1 t2) -> Set.union (tyFreeVars t1) (tyFreeVars t2)
+
+-- | @occursIn x t@, does `x` appear in `t`?
+occursIn :: TyVar -> X86Ty -> Bool
+occursIn x ty = Set.member x $ tyFreeVars ty
+
+
+-- | x86 type constraints
+data X86TyConstraint
+  = -- | An equality constraint.
+    EqC X86Ty X86Ty
+  | -- | A subtype constraint.
+    SubC X86Ty X86Ty
+  | OrC [X86TyConstraint]
+  | AndC [X86TyConstraint]
+
+
+cSubst :: TyVar -> X86Ty -> X86TyConstraint -> X86TyConstraint
+cSubst x xTy constraint = go constraint
+  where go :: X86TyConstraint -> X86TyConstraint
+        go (EqC t1 t2)  = EqC (subst x xTy t1) (subst x xTy t2)
+        go (SubC t1 t2) = SubC (subst x xTy t1) (subst x xTy t2)
+        go (OrC cs)     = OrC (map go cs)
+        go (AndC cs)    = AndC (map go cs)
+
+
+-- | @decompSubC t1 t2@ decomposes `t1 <: t2` into any implied constraints. Cf.
+-- TIE's `Υ` operator from § 6.3.2.
+decomposeSubC :: X86Ty -> X86Ty -> [X86TyConstraint]
+decomposeSubC (PtrTy t1) (PtrTy t2) = [SubC t1 t2]
+decomposeSubC t1 (AndTy t2 t3) = [SubC t1 t2, SubC t1 t3]
+decomposeSubC (OrTy t1 t2) t3 = [SubC t1 t3, SubC t2 t3]
+decomposeSubC _ _ = []
+
+data ConstraintSet
+  = ConstraintSet
+    { csEqConstraints  :: [(X86Ty, X86Ty)]
+    , csSubConstraints :: [(X86Ty, X86Ty)]
+    , csOrConstraints  :: [[X86TyConstraint]]
+    }
+
+emptyConstraintSet :: ConstraintSet
+emptyConstraintSet = ConstraintSet [] [] []
+
+csetSubst :: TyVar -> X86Ty -> ConstraintSet -> ConstraintSet
+csetSubst x xTy (ConstraintSet eqs subs ors) = ConstraintSet eqs' subs' ors'
+  where pSubst (t1,t2) = (subst x xTy t1, subst x xTy t2)
+        eqs'  = map pSubst eqs
+        subs' = map pSubst subs
+        ors'  = map (map (cSubst x xTy)) ors
+
+
+data ConstraintInfo
+  = ConstraintInfo
+    { -- | Map from type variables to their known subtypes.
+      -- One half of `S_{<:}` from TIE § 6.3.
+      ciSubtypeCache :: Map TyVar (Set X86Ty)
+      -- | Map from type variables to their known supertypes.
+      -- One half of `S_{<:}` from TIE § 6.3.
+    , ciSupertypeCache :: Map TyVar (Set X86Ty)
+    -- | Known type for type variables. `S_{=}` from TIE § 6.3.
+    , ciVarTypes :: Map TyVar X86Ty
+    -- | Upper bounds for type variables. `B^{↑}` from TIE § 6.3.
+    , ciVarUpperBounds :: Map TyVar X86Ty
+    -- | Lower bounds for type variables. `B^{↓}` from TIE § 6.3.
+    , ciVarLowerBounds :: Map TyVar X86Ty
+    }
+
+-- | Concretize the type using any available upper bounds for type variables.
+currentUpperBound :: X86Ty -> ConstraintInfo -> X86Ty
+currentUpperBound t cinfo = concretize t lookup
+  where lookup x = Map.findWithDefault TopTy x (ciVarUpperBounds cinfo)
+
+-- | Concretize the type using any available lower bounds for type variables.
+currentLowerBound :: X86Ty -> ConstraintInfo -> X86Ty
+currentLowerBound t cinfo = concretize t lookup
+  where lookup x = Map.findWithDefault BotTy x (ciVarLowerBounds cinfo)
+
+emptyConstraintInfo :: ConstraintInfo
+emptyConstraintInfo = ConstraintInfo Map.empty Map.empty Map.empty Map.empty Map.empty
+
+addConstraints :: [X86TyConstraint] -> ConstraintSet -> ConstraintSet
+addConstraints [] cset = cset
+addConstraints ((EqC  t1 t2):cs) cset = addConstraints cs (cset {csEqConstraints = (t1,t2):csEqConstraints cset})
+addConstraints ((SubC t1 t2):cs) cset = addConstraints cs (cset {csSubConstraints = (t1,t2):csSubConstraints cset})
+addConstraints ((OrC cs'):cs) cset = addConstraints cs (cset {csOrConstraints = cs':csOrConstraints cset})
+addConstraints ((AndC cs'):cs) cset = addConstraints (cs'++cs) cset
+
+-- | Partition the constraints into the @ConstraintSet@, which we use to order
+-- which are handled when during unification.
+initConstraintSet :: [X86TyConstraint] -> ConstraintSet
+initConstraintSet constraints = addConstraints constraints emptyConstraintSet
+
+-- | @solveEqC (t1,t2) cset cinfo@ updates @cset@ and @cinfo@ with the equality
+-- `t1 == t2`. Cf. TIE Algorithm 1. If @Nothing@ is returned, the equality
+-- failed the occurs check.
+solveEqC :: (X86Ty,X86Ty) -> (ConstraintSet, ConstraintInfo) -> Maybe (ConstraintSet, ConstraintInfo)
+solveEqC (VarTy x, t2) (cset, cinfo) =
+  let varTypes = ciVarTypes cinfo in
+    if occursIn x t2 then
+      Nothing
+    else
+      case Map.lookup x varTypes of
+        Just xTy -> solveEqC (xTy, t2) (cset, cinfo)
+        Nothing ->
+          let varTypes' = Map.insert x t2 varTypes in
+            Just (csetSubst x t2 cset, cinfo{ciVarTypes = varTypes'})
+solveEqC (t1, t2@(VarTy _)) (cset, cinfo) =
+  solveEqC (t2, t1) (cset, cinfo)
+solveEqC (PtrTy t1, PtrTy t2) (cset, cinfo) =
+  Just (cset{csEqConstraints = (t1,t2):csEqConstraints cset} , cinfo)
+solveEqC _ (cset, cinfo) = Just (cset, cinfo)
+
+
+-- | Given `t1 <: t2`, if `t1` is a type variable `x`, update the upper bounds
+-- of any subtypes. I.e., ∀ `y` s.t.`y <: x`, we now know `y <: t2`. Cf. rule
+-- (2) in the Decomposition Rules of § 6.3.2.
+updateUpperBounds :: (X86Ty,X86Ty) -> (ConstraintSet, ConstraintInfo) -> (ConstraintSet, ConstraintInfo)
+updateUpperBounds (xTy@(VarTy x),t2) initial = Map.foldrWithKey update initial (ciSupertypeCache $ snd initial)
+  where
+    update :: TyVar -> Set X86Ty -> (ConstraintSet, ConstraintInfo) -> (ConstraintSet, ConstraintInfo)
+    update y ySuperTySet (cset, cinfo) =
+      if not $ Set.member xTy ySuperTySet
+        then -- `y </: x`, so there's nothing to update
+          (cset, cinfo)
+      else -- `y <: x` implying `y <: t2`
+        -- AMK: TIE suggests updating cset with `Υ(α <: S)` but also
+        -- seems to suggest doing so would be a no-op when they describe `Υ`:
+        -- "For constraints on basic type variables, where
+        -- further decomposition is not possible, the
+        -- decomposition operator returns an empty set (∅)."
+        let cset' = cset
+            -- add `y <: t2` to our known supertypes
+            cinfo' = cinfo{ciSupertypeCache = Map.insert y (Set.insert t2 ySuperTySet) (ciSupertypeCache cinfo)}
+            -- update y upper bound to it's current upper bound ⊓ t2's current upper bound
+            yUB = upperBound (currentUpperBound (VarTy y) cinfo') (currentUpperBound (VarTy y) cinfo')
+          in (cset', cinfo'{ciVarUpperBounds = Map.insert y yUB (ciVarUpperBounds cinfo')})
+updateUpperBounds (_,_) (cset, cinfo) = (cset, cinfo)
+
+-- | Given `t1 <: t2`, if `t2` is a type variable `x`, update the lower bounds
+-- of any supertypes. I.e., ∀ `y` s.t.`x <: y`, we want to record `t1 <: y`. Cf.
+-- rule (3) in the Decomposition Rules of § 6.3.2.
+updateLowerBounds :: (X86Ty,X86Ty) -> (ConstraintSet, ConstraintInfo) -> (ConstraintSet, ConstraintInfo)
+updateLowerBounds (t1,VarTy x) (cset, cinfo) = undefined -- FIXME
+updateLowerBounds (_, _)  (cset, cinfo) = (cset, cinfo)
+
+-- | @solveSubC (t1,t2) cset cinfo@ updates @cset@ and @cinfo@ with the subtype constraint
+-- `t1 <: t2`. Cf. TIE § 6.3.2.
+solveSubC :: (X86Ty,X86Ty) -> (ConstraintSet, ConstraintInfo) -> (ConstraintSet, ConstraintInfo)
+solveSubC (t1,t2) (cset, cinfo) =
+    -- If `t1 <: t2` the contraint is trivial and should be discarded.
+    if subtype t1 t2 then (cset, cinfo)
+    else let (cset', cinfo') = updateLowerBounds (t1,t2)
+                               $ updateUpperBounds (t1,t2)
+                               $ (cset, cinfo)
+           in (addConstraints (decomposeSubC t1 t2) cset', cinfo')
+
+
+newtype X86TyUnificationError = X86TyUnificationError String
+
+
+-- | Unify the given constraints, returning a conservative type map for all type
+-- variables.
+unifyConstraints :: [X86TyConstraint] -> Either X86TyUnificationError (Map TyVar X86Ty)
+unifyConstraints initialConstraints = undefined -- FIXME
+
+
+-- Questions
+-- 1. When does unification fail assuming we have ironed out all the wrinkles in
+--    the algorithm? Is that just when it can't decide on a precise type?
+-- 2. Is the current `X86Ty` the right type to return to other parts of Reopt?
+--    Or are too many parts of it artifacts of the TIE unification algorithm?
+--    I'm leaning towards the latter, and we should have a `X86ConcreteTy` data
+--    type basically which does not include top/botton/union/etc.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -3,64 +3,16 @@ module Main ( main ) where
 import System.FilePath.Glob ( namesMatching )
 import qualified Test.Tasty as T
 
-import Reopt.TypeInference.Constraints
-  (TyVar(..),
-   Ty(..),
-   andTy,
-   orTy,
-   ptrTy,
-   TyConstraint(..),
-   andC,
-   orC,
-   initContext,
-   processAtomicConstraints,
-   int32Ty,
-   int64Ty)
 import qualified ReoptTests as T
+import qualified TyConstraintTests as TC
 import qualified Prettyprinter as PP
-
-constraintTest :: String -> [TyConstraint] -> IO ()
-constraintTest testName cs = do
-  putStrLn $ "\nConstraint Test: " ++ testName
-  let initCtx = initContext cs
-  putStrLn $ "  Initial Context:"
-  putStrLn (show $ PP.indent 4 $ PP.pretty initCtx)
-  let resultCtx = processAtomicConstraints initCtx
-  putStrLn $ "  Result Context:"
-  putStrLn (show $ PP.indent 4 $ PP.pretty resultCtx)
-
-
-x0,x1,x2,x3 :: TyVar
-x0Ty,x1Ty,x2Ty,x3Ty :: Ty
-x0   = TyVar 0
-x0Ty = VarTy x0
-x1   = TyVar 1
-x1Ty = VarTy x1
-x2   = TyVar 2
-x2Ty = VarTy x2
-x3   = TyVar 3
-x3Ty = VarTy x3
 
 main :: IO ()
 main = do
-  -- constraintTest "No Constraints" []
-  -- constraintTest "One EqC" [ EqC x0Ty TopTy ]
-  -- constraintTest "Two EqC" [ EqC x0Ty TopTy
-  --                          , EqC x1Ty int32Ty]
-  -- constraintTest "Alias EqC 1"
-  --   [ EqC x0Ty x1Ty
-  --   , EqC x1Ty int32Ty]
-  -- constraintTest "Alias EqC 2"
-  --   [ EqC x1Ty x0Ty
-  --   , EqC x1Ty int32Ty]
-  -- constraintTest "Alias EqC 2"
-  --   [ EqC x0Ty x1Ty
-  --   , SubC x1Ty int64Ty
-  --   , SubC x2Ty x1Ty
-  --   , SubC x2Ty int64Ty]
 
   x64AsmTests <- namesMatching "tests/x64/*.exe"
   T.defaultMain $ T.testGroup "ReoptTests" [
+    TC.constraintTests,
     T.reoptTests x64AsmTests
     ]
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -3,10 +3,62 @@ module Main ( main ) where
 import System.FilePath.Glob ( namesMatching )
 import qualified Test.Tasty as T
 
+import Reopt.TypeInference.Constraints
+  (TyVar(..),
+   Ty(..),
+   andTy,
+   orTy,
+   ptrTy,
+   TyConstraint(..),
+   andC,
+   orC,
+   initContext,
+   processAtomicConstraints,
+   int32Ty,
+   int64Ty)
 import qualified ReoptTests as T
+import qualified Prettyprinter as PP
+
+constraintTest :: String -> [TyConstraint] -> IO ()
+constraintTest testName cs = do
+  putStrLn $ "\nConstraint Test: " ++ testName
+  let initCtx = initContext cs
+  putStrLn $ "  Initial Context:"
+  putStrLn (show $ PP.indent 4 $ PP.pretty initCtx)
+  let resultCtx = processAtomicConstraints initCtx
+  putStrLn $ "  Result Context:"
+  putStrLn (show $ PP.indent 4 $ PP.pretty resultCtx)
+
+
+x0,x1,x2,x3 :: TyVar
+x0Ty,x1Ty,x2Ty,x3Ty :: Ty
+x0   = TyVar 0
+x0Ty = VarTy x0
+x1   = TyVar 1
+x1Ty = VarTy x1
+x2   = TyVar 2
+x2Ty = VarTy x2
+x3   = TyVar 3
+x3Ty = VarTy x3
 
 main :: IO ()
 main = do
+  -- constraintTest "No Constraints" []
+  -- constraintTest "One EqC" [ EqC x0Ty TopTy ]
+  -- constraintTest "Two EqC" [ EqC x0Ty TopTy
+  --                          , EqC x1Ty int32Ty]
+  -- constraintTest "Alias EqC 1"
+  --   [ EqC x0Ty x1Ty
+  --   , EqC x1Ty int32Ty]
+  -- constraintTest "Alias EqC 2"
+  --   [ EqC x1Ty x0Ty
+  --   , EqC x1Ty int32Ty]
+  -- constraintTest "Alias EqC 2"
+  --   [ EqC x0Ty x1Ty
+  --   , SubC x1Ty int64Ty
+  --   , SubC x2Ty x1Ty
+  --   , SubC x2Ty int64Ty]
+
   x64AsmTests <- namesMatching "tests/x64/*.exe"
   T.defaultMain $ T.testGroup "ReoptTests" [
     T.reoptTests x64AsmTests

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,7 +5,6 @@ import qualified Test.Tasty as T
 
 import qualified ReoptTests as T
 import qualified TyConstraintTests as TC
-import qualified Prettyprinter as PP
 
 main :: IO ()
 main = do

--- a/tests/TyConstraintTests.hs
+++ b/tests/TyConstraintTests.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module TyConstraintTests
+  ( constraintTests,
+  )
+where
+
+import Data.List (sortBy)
+import qualified Data.Map as Map
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import qualified Prettyprinter as PP
+
+import Reopt.TypeInference.Constraints
+  (TyVar(..),
+   Ty(..),
+   TyConstraint(..),
+   unifyConstraints,
+   orC,
+   andC,
+   andTy,
+   orTy,
+   ptrTy,
+   int32Ty,
+   int64Ty)
+
+x0,x1,x2,x3 :: TyVar
+x0Ty,x1Ty,x2Ty,x3Ty :: Ty
+x0   = TyVar 0
+x0Ty = VarTy x0
+x1   = TyVar 1
+x1Ty = VarTy x1
+x2   = TyVar 2
+x2Ty = VarTy x2
+x3   = TyVar 3
+x3Ty = VarTy x3
+
+constraintTests :: T.TestTree
+constraintTests = T.testGroup "Type Constraint Tests"
+  [ eqCTests
+  , subCTests
+  , orCTests
+  ]
+
+-- Simple tests having to do with equality constraints
+eqCTests :: T.TestTree
+eqCTests = T.testGroup "Equality Constraint Tests"
+  [ mkTest "Single EqC var left"  [EqC x0Ty int64Ty] [(x0, int64Ty)],
+    mkTest "Single EqC var right" [EqC int64Ty x0Ty] [(x0, int64Ty)],
+    mkTest "Multiple EqCs" [EqC x0Ty int64Ty, EqC x1Ty int32Ty]
+                            [(x0, int64Ty), (x1, int32Ty)],
+    mkTest "EqC Transitivity 1" [EqC x0Ty x1Ty, EqC x1Ty int32Ty]
+                                 [(x0, int32Ty), (x1, int32Ty)],
+    mkTest "EqC Transitivity 2" [EqC x1Ty int32Ty, EqC x0Ty x1Ty]
+                                 [(x0, int32Ty), (x1, int32Ty)],
+    mkTest "EqC Transitivity 2" [EqC x1Ty x2Ty, EqC x0Ty x1Ty, EqC x2Ty int64Ty]
+                                 [(x0, int64Ty), (x1, int64Ty), (x2, int64Ty)]
+  ]
+
+-- Simple tests having to do with equality constraints.
+subCTests :: T.TestTree
+subCTests = T.testGroup "Equality Constraint Tests"
+  [ mkTest "Single SubC upper bound"  [SubC x0Ty int64Ty] [(x0, int64Ty)],
+    mkTest "Single SubC lower bound"  [SubC int64Ty x0Ty] [(x0, int64Ty)],
+    mkTest "Single SubC lower+upper bounds" [SubC x0Ty int64Ty, SubC int32Ty x0Ty]
+                                            [(x0, int32Ty)],
+    mkTest "Multiple SubCs 1"  [SubC int64Ty x0Ty, SubC x0Ty int64Ty] [(x0, int64Ty)],
+    mkTest "Multiple SubCs 2"  [SubC int64Ty x0Ty, SubC x0Ty int64Ty, SubC x1Ty int32Ty]
+                               [(x0, int64Ty), (x1, int32Ty)],
+    mkTest "Multiple SubCs 3"  [SubC int64Ty x0Ty, SubC x0Ty int64Ty, SubC x1Ty int32Ty, SubC x1Ty x0Ty]
+                               [(x0, int64Ty), (x1, int32Ty)],
+    mkTest "SubC Transitivity 1"
+      [SubC x0Ty int64Ty, SubC x1Ty x0Ty]
+      [(x0, int64Ty), (x1, int64Ty)],
+    mkTest "SubC Transitivity 2"
+      [SubC x0Ty int64Ty, SubC x1Ty x0Ty]
+      [(x0, int64Ty), (x1, int64Ty)]
+  ]
+
+-- | Some (basic?) tests focusing on disjunctions.
+orCTests :: T.TestTree
+orCTests = T.testGroup "Disjunctive Constraint Tests"
+  [ mkTest "disjunctive syllogism 1"
+      [ orC [andC [EqC x0Ty (ptrTy 64 int64Ty), SubC x1Ty int64Ty],
+             andC [EqC x1Ty (ptrTy 64 int64Ty), SubC x0Ty int64Ty]],
+        SubC x0Ty int64Ty]
+      [(x0, int64Ty), (x1, ptrTy 64 int64Ty)],
+    mkTest "disjunctive syllogism 2"
+      [ orC [andC [EqC x0Ty (ptrTy 64 int64Ty), SubC x1Ty int64Ty],
+             andC [EqC x1Ty (ptrTy 64 int64Ty), SubC x0Ty int64Ty],
+             andC [SubC x0Ty int64Ty, SubC x0Ty int64Ty]],
+        SubC int32Ty x0Ty,
+        SubC int32Ty x1Ty]
+      [(x0, int32Ty), (x1, int32Ty)],
+    mkTest "disjunctive syllogism 3"
+      [ orC [andC [EqC x0Ty (ptrTy 64 int64Ty), SubC x1Ty int64Ty],
+             andC [EqC x1Ty (ptrTy 64 int64Ty), SubC x0Ty int64Ty],
+             andC [SubC x0Ty int64Ty, SubC x0Ty int64Ty]],
+        SubC x2Ty x0Ty,
+        SubC x3Ty x1Ty,
+        SubC int32Ty x2Ty,
+        SubC int32Ty x3Ty]
+      [(x0, int32Ty), (x1, int32Ty), (x2, int32Ty), (x3, int32Ty)]
+  ]
+
+newtype TypeEnv = TypeEnv [(TyVar, Ty)]
+  deriving (Eq)
+
+instance Show TypeEnv where
+  show (TypeEnv xs) = show $ map (\(x,xTy) -> (PP.pretty x, PP.pretty xTy)) xs
+
+tyEnv :: [(TyVar, Ty)] -> TypeEnv
+tyEnv = let cmp (x,_) (y,_) = compare x y
+          in TypeEnv . sortBy cmp
+
+mkTest :: String -> [TyConstraint] -> [(TyVar, Ty)] -> T.TestTree
+mkTest name cs expected =
+  let actual = Map.toList $ unifyConstraints cs
+    in T.testCase name $ (tyEnv actual) T.@?= (tyEnv expected)
+
+
+
+

--- a/tests/TyConstraintTests.hs
+++ b/tests/TyConstraintTests.hs
@@ -8,6 +8,8 @@ module TyConstraintTests
   )
 where
 
+import Data.Bifunctor (bimap)
+import Data.Function (on)
 import Data.List (sortBy)
 import qualified Data.Map as Map
 import qualified Test.Tasty as T
@@ -110,11 +112,10 @@ newtype TypeEnv = TypeEnv [(TyVar, Ty)]
   deriving (Eq)
 
 instance Show TypeEnv where
-  show (TypeEnv xs) = show $ map (\(x,xTy) -> (PP.pretty x, PP.pretty xTy)) xs
+  show (TypeEnv xs) = show $ bimap PP.pretty PP.pretty <$> xs
 
 tyEnv :: [(TyVar, Ty)] -> TypeEnv
-tyEnv = let cmp (x,_) (y,_) = compare x y
-          in TypeEnv . sortBy cmp
+tyEnv = TypeEnv . sortBy (compare `on` fst)
 
 mkTest :: String -> [TyConstraint] -> [(TyVar, Ty)] -> T.TestTree
 mkTest name cs expected =

--- a/tests/TyConstraintTests.hs
+++ b/tests/TyConstraintTests.hs
@@ -23,8 +23,6 @@ import Reopt.TypeInference.Constraints
    unifyConstraints,
    orC,
    andC,
-   andTy,
-   orTy,
    ptrTy,
    int32Ty,
    int64Ty)


### PR DESCRIPTION
Includes an initial implementation of the core of the type constraint system described in "TIE: Principled Reverse Engineering of Types in Binary Programs" and a few simple tests.

Notable omissions at present are as follows:
+ no memory/record representation currently (presumably this isn't _hard_ to add per se, but it appears to involve lots of subtleties the paper hand waves about presumably for LaTeX clarity)
+ we do not _merge_ info from disjunctions yet (see §6.3.4 of TIE paper), we only see if certain disjuncts are absurd and attempt to reduce the disjunction into simpler constraint