### PR TITLE
connect constraint generation and constraint solving

### DIFF
--- a/reopt/Main_reopt.hs
+++ b/reopt/Main_reopt.hs
@@ -716,11 +716,13 @@ showConstraints args = do -- FIXME: copied from main performReopt command
     pure (genModule recMod (memory discState))
 
   mc <-   handleEitherWithExit mr
-    
+
   putStrLn "Warnings"
   putStrLn (unlines (map ((++) "\t" . show) (mcWarnings mc)))
-  putStrLn "Constraints"    
+  putStrLn "Constraints"
   putStrLn (unlines (map ((++) "\t" . show) (mcConstraints mc)))
+  putStrLn "Inferred types"
+  putStrLn (showInferredTypes mc)
 
 ------------------------------------------------------------------------
 -- Reopt action
@@ -857,6 +859,9 @@ performReopt args = do
         reoptWriteByteString RelinkerInfoFileType path (Aeson.encode relinkerInfo)
 
     unless (shouldGenerateLLVM args) $ reoptEndNow ()
+
+    -- Generate constraints
+    let _moduleConstraints = genModule recMod (memory discState)
 
     -- Generate LLVM
     let (objLLVM, ann, ext, _logEvents) =


### PR DESCRIPTION
We can now run the pipeline of constraint generation all the way through
constraint solving and display the results of the solving process.

Results are now displaying the generated constraints (which are informative but
in terms of fresh type variables so hard to understand), and the inferred types
for all user-facing variables.

This also solves a bug where we were conflating `FnAssignId`s across
`Function`s, and reengineers the constraint generation monad to be
parameterized by an increasingly-populated context as we go down modules,
functions, and function blocks.