### PR TITLE
structural constraint types

### DIFF
--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -276,7 +276,10 @@ subtype' resolveL resolveR = go
         -- Signed/Unsigned integer subtypes
         (IntTy w1,  IntTy w2)  -> w1 <= w2
         (UIntTy w1, UIntTy w2) -> w1 <= w2
-        -- Records
+        -- Records FIXME (?) there is some concern about reasoning too deeply
+        -- about structural subtyping and soundness we need to hammer out,
+        -- especially when dealing with pointers being passed around within
+        -- things. (This could apply to pointer pointers as well perhaps...?)
         (RecTy flds1, RecTy flds2) -> all (\(fld, fldTy2) ->
                                             case Map.lookup fld flds1 of
                                               Nothing -> False
@@ -346,7 +349,11 @@ upperBound type1 type2 =
     (s, t@(VarTy _)) -> orTy [s,t]
     -- J-Ptr (N.B., TIE uses ⊓ in this rule, but I think that's a typo)
     ((PtrTy w1 s), (PtrTy w2 t)) | w1 == w2 -> ptrTy w1 (upperBound s t)
-    -- J-RecBase
+    -- J-RecBase // FIXME (?) these cases are in the TIE paper, but without more
+    -- complex record upper bound calculations there arguably useless (i.e.,
+    -- subtyping would already have checked the same thing, and so we likely
+    -- will just get `TopTy` out as `upperBound` doesn't know what to do with
+    -- two record types currently)
     (t1, t2@RecTy{}) | isBaseTy t1 -> upperBound (recTy' [(0,t1)]) t2
     (t1@RecTy{}, t2) | isBaseTy t2 -> upperBound t1 (recTy' [(0,t2)])
     -- J-NoRel

--- a/src/Reopt/TypeInference/Constraints.hs
+++ b/src/Reopt/TypeInference/Constraints.hs
@@ -152,6 +152,7 @@ ptrTy w t = PtrTy w t
 -- | @readAtTy t i@ is the type which begins @i@ bits into @t@.
 readAtTy :: Ty -> Int -> Ty
 readAtTy t@(RecTy flds) i = Map.findWithDefault (ReadAtTy t i) i flds
+readAtTy (UpdateAtTy _ i t2) j | i == j = t2
 readAtTy t i = ReadAtTy t i
 
 -- | @updateAtTy t1 i t2@ is the result up writing a @t2@ at @i@ bits into @t1@.


### PR DESCRIPTION
Adds a record type (`RecTy`) and types essentially for describing indexing into records (`ReadAtTy`) and updating records (`UpdateAtTy`). The intent is that `ReadAtTy` and `UpdateAtTy` _only_ appear in types when the underlying type being indexed/updated is unknown, and once the underlying type is known and has an appropriate structure the type is reduced (see smart constructors `readAtTy` and `updateAtTy`). These type constructors correspond to some of the undocumented type operators that appear in the TIE paper (e.g., see Figure 7's entries for `load` and `store`).

Records are treated elementary presently (e.g., we treat them as maps from offsets to types, but ignore possible overlap etc); this could obviously be enhanced if desired. (It's not clear in my mind how much effort is worthwhile in this particular space... similar to how the treatment of unions and intersections is currently limited IMO.)