### PR TITLE
detect the actual tar version present on the system

### DIFF
--- a/scripts/unpack_benchmarks.sh
+++ b/scripts/unpack_benchmarks.sh
@@ -16,7 +16,7 @@ unlzma_mv_untar () {
   fi
   TARVER=`tar --version | head -n 1`
   if [[ "$TARVER" =~ "tar (GNU tar)" ]]; then
-    tar --overwrite -xf $TAR_FILE
+    tar -xf $TAR_FILE
   elif [[ "$TARVER" =~ "bsdtar" ]]; then
     tar -xkf $TAR_FILE
   else

--- a/scripts/unpack_benchmarks.sh
+++ b/scripts/unpack_benchmarks.sh
@@ -14,10 +14,14 @@ unlzma_mv_untar () {
   if [[ "$TAR_FILE.lzma" -nt "$TAR_FILE"  ]] ; then
     unlzma -k "$TAR_FILE.lzma"
   fi
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  TARVER=`tar --version | head -n 1`
+  if [[ "$TARVER" =~ "tar (GNU tar)" ]]; then
+    tar --overwrite -xf $TAR_FILE
+  elif [[ "$TARVER" =~ "bsdtar" ]]; then
     tar -xkf $TAR_FILE
   else
-    tar --overwrite -xf $TAR_FILE
+    echo "Unknown version of tar, please report!"
+    exit 1
   fi
   echo " done!"
   popd # $DIR
@@ -34,4 +38,4 @@ unlzma_mv_untar "lib64.tar" "centos7-dev/lib64"
 unlzma_mv_untar "debug-lib64.tar" "centos7-dev/debug-lib64"
 
 
-popd > /dev/null # $BENCHMARK_DIR 
+popd > /dev/null # $BENCHMARK_DIR


### PR DESCRIPTION
The current script does not work on my machine because it assumes that any
machine running Darwin will also have bsdtar.  I am running Darwin, but have
also installed the superior GNU tar, so the assumption does not hold.

Instead, I made it read the `--version` output to see if we identify either GNU
or BSD version of tar.