### PR TITLE
don't create two type variables for phi nodes

### DIFF
--- a/src/Reopt/TypeInference/ConstraintGen.hs
+++ b/src/Reopt/TypeInference/ConstraintGen.hs
@@ -287,13 +287,27 @@ atFnAssignId ::
   Lens' (CGenState arch) (Maybe TyVar)
 atFnAssignId fn aId = assignTyVars . at fn . non Map.empty . at aId
 
--- | Creates a new type variable and associates it with the assignment
-freshTyVarForAssignId :: BSC.ByteString -> FnAssignId -> CGenM ctx arch TyVar
-freshTyVarForAssignId fn aId = do
-  -- fn <- askContext cgenCurrentFunName
-  tyv <- freshTyVar (show aId <> " in " <> show fn)
-  CGenM $ atFnAssignId fn aId ?= tyv
-  pure tyv
+
+-- | Retrieves the type variable associated to the given `FnAssignId`, if any,
+-- otherwise creates and registers a fresh type variable for it.
+--
+-- NOTE: This does **not** use the function name present in the monadic context,
+-- because we sometimes wants to resolve assign ids for other functions than the
+-- one currently being analyzed.
+tyVarForAssignId ::
+  -- | Function defining the `FnAssignId`
+  BSC.ByteString ->
+  FnAssignId ->
+  CGenM ctx arch TyVar
+tyVarForAssignId fn aId = do
+  mtv <- CGenM $ use (atFnAssignId fn aId)
+  case mtv of
+    Just tv -> pure tv
+    Nothing -> do
+      tyv <- freshTyVar (show aId <> " in " <> show fn)
+      CGenM $ atFnAssignId fn aId ?= tyv
+      pure tyv
+
 
 -- freshForCallRet :: FnReturnVar tp -> CGenM ctx arch TyVar
 -- freshForCallRet a = do
@@ -309,7 +323,7 @@ assignIdTyVar fn aId = do
   -- fn <- askContext cgenCurrentFunName
   mTyVar <- CGenM $ use (atFnAssignId fn aId)
   case mTyVar of
-    Nothing -> freshTyVarForAssignId fn aId
+    Nothing -> tyVarForAssignId fn aId
     Just tyVar -> pure tyVar
 
 -- | Returns the associated type for a function assignment id, if any.
@@ -607,7 +621,7 @@ genFnAssignment ::
   FnAssignment arch tp -> CGenM CGenBlockContext arch ()
 genFnAssignment a = do
   fn <- askContext (cgenFunctionContext . cgenCurrentFunName)
-  ty <- varITy <$> freshTyVarForAssignId fn (fnAssignId a)
+  ty <- varITy <$> tyVarForAssignId fn (fnAssignId a)
   case fnAssignRhs a of
     FnSetUndefined {} -> pure () -- no constraints generated
     FnReadMem ptr sz -> genMemOp ty ptr (Some sz)
@@ -741,7 +755,7 @@ genFunction fn {- blockPhis -} = do
     <$> askContext cgenFunTypes
   let mkPhis b =
         let phiVars = viewSome unFnPhiVar <$> V.toList (fbPhiVars b) in
-        let mkPhiVar aId = varITy <$> freshTyVar ("%phi " <> show aId) in
+        let mkPhiVar aId = varITy <$> tyVarForAssignId (fnName fn) aId in
         (,) (fbLabel b) <$> mapM mkPhiVar phiVars
   bphis <- Map.fromList <$> mapM mkPhis (fnBlocks fn)
   withinContext


### PR DESCRIPTION
We were unfortunately creating two separate type variables for phi nodes'
`FnAssignId`s: one where the phi node was emitted, and one the first time the
phi variable was referenced in code.

We now make sure to check for an existing type variable for any `FnAssignId`
before deciding to create a fresh one.