### PR TITLE
override pointer type when emitting `getelementptr`

### DIFF
--- a/src/Reopt/CFG/LLVM.hs
+++ b/src/Reopt/CFG/LLVM.hs
@@ -969,9 +969,10 @@ llvmGetElementPtr ::
   FnValue arch (BVType n) ->
   BBLLVM arch (L.Typed L.Value)
 llvmGetElementPtr pointee ptr ofs = do
-  ptrV <- mkLLVMValue ptr
+  L.Typed _ ptrV <- mkLLVMValue ptr
+  let pointerType = L.PtrTo pointee
   ofsV <- mkLLVMValue ofs
-  L.Typed (L.PtrTo pointee) <$> evalInstr (L.GEP False ptrV [ofsV])
+  L.Typed pointerType <$> evalInstr (L.GEP False (L.Typed pointerType ptrV) [ofsV])
 
 
 -- | Emits a `getelementptr` instruction, but assumes the given pointer value is


### PR DESCRIPTION
When emitting `getelementptr`, we know the pointee type, and it does not
correspond to the type obtained in recovery (which will always be `i64`).
Therefore we need to ignore that type and put the actual, inferred pointee
type.