### PR TITLE
make GHC 9.2.6 compatible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Set env.home and enc.ghc
+    - name: Set env.home and env.ghc
       run: |
         echo "home=$HOME" >> $GITHUB_ENV
         echo "ghc=`ghc --version --help | cut -d' ' -f8`" >> $GITHUB_ENV

--- a/annotations/src/Reopt/VCG/SMTParser.hs
+++ b/annotations/src/Reopt/VCG/SMTParser.hs
@@ -27,6 +27,7 @@ module Reopt.VCG.SMTParser
 import           Control.Monad
 import           Data.Attoparsec.Text
 import           Data.Bits
+import           Data.Kind (Type)
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -113,7 +114,7 @@ data ExprType
 --
 -- The type @A@ allows one to create holes for
 -- variables or other known constants.
-data Expr (v :: *) where
+data Expr (v :: Type) where
   Eq    :: !(Expr v) -> !(Expr v) -> Expr v
   BVAdd :: !(Expr v) -> !(Expr v) -> Expr v
   BVSub :: !(Expr v) -> !(Expr v) -> Expr v

--- a/containers/dev-with-builds/Dockerfile
+++ b/containers/dev-with-builds/Dockerfile
@@ -8,9 +8,9 @@ RUN  curl -o /root/.ghcup/bin/ghcup https://downloads.haskell.org/~ghcup/0.1.14.
  && chmod a+x /root/.ghcup/bin/ghcup
 
 # Install GHC
-RUN ghcup install ghc 8.10.5 \
+RUN ghcup install ghc 8.10.7 \
  && ghcup install cabal 3.4.0.0 \
- && ghcup set ghc 8.10.5
+ && ghcup set ghc 8.10.7
 
 COPY . /home/vadd/reopt
 
@@ -24,4 +24,3 @@ RUN cabal build exe:reopt exe:reopt-explore
 RUN cp /home/vadd/reopt-vcg/deps/cvc4-2020-09-16-x86_64-linux-opt /usr/local/bin/cvc4
 COPY ./containers/dev-with-builds/README.md /home/vadd
 WORKDIR /home/vadd
-

--- a/containers/dev/Dockerfile
+++ b/containers/dev/Dockerfile
@@ -10,14 +10,17 @@ ENV PATH=/opt/rh/devtoolset-8/root/bin:${PATH}
 
 # Install GHCUP
 ENV PATH=/root/.ghcup/bin:${PATH}
+ARG ghcupVer=0.1.19.0
+ARG cabalVer=3.4.0.0
+ARG ghcVer=8.10.7
 
 RUN mkdir -p /root/.ghcup/bin
-RUN  curl -o /root/.ghcup/bin/ghcup https://downloads.haskell.org/~ghcup/0.1.14.1/x86_64-linux-ghcup-0.1.14.1 \
+RUN  curl -o /root/.ghcup/bin/ghcup https://downloads.haskell.org/~ghcup/${ghcupVer}/x86_64-linux-ghcup-${ghcupVer} \
  && chmod a+x /root/.ghcup/bin/ghcup
 
 # Install GHC
-RUN ghcup install ghc 8.10.5 \
- && ghcup install cabal 3.4.0.0 \
- && ghcup set ghc 8.10.5
+RUN ghcup install ghc ${ghcVer} \
+ && ghcup install cabal ${cabalVer} \
+ && ghcup set ghc ${ghcVer}
 
 WORKDIR /root

--- a/reopt-explore/Residual.hs
+++ b/reopt-explore/Residual.hs
@@ -48,6 +48,7 @@ import           Reopt.Utils.Exit              (checkedReadFile,
 import           CommandLine                   (Options,
                                                 ResidualOptions (roClangPath, roHeader, roOutputForSpreadsheet, roPaths))
 import           Common                        (findAllElfFilesInDirs)
+import           Data.Either                   (fromRight)
 import           Data.ElfEdit                  (ElfHeaderInfo,
                                                 Shdr (shdrAddr, shdrName, shdrSize),
                                                 Symtab (symtabEntries),
@@ -313,7 +314,7 @@ constructResidualRangeInfos ::
   [ResidualRangeInfo]
 constructResidualRangeInfos hdrInfo mem recovOut residuals =
   let
-    Right shdrs = headerNamedShdrs hdrInfo
+    shdrs = fromRight (error "shdrs") $ headerNamedShdrs hdrInfo
     rangedShdrs = mapMaybe rangedShdr (Vec.toList shdrs)
     mSymTab = either (error . show) id <$> decodeHeaderSymtab hdrInfo
     allSymbols = map steValue . Vec.toList . symtabEntries @64 <$> mSymTab

--- a/reopt-explore/Residual/Recognizers.hs
+++ b/reopt-explore/Residual/Recognizers.hs
@@ -7,6 +7,7 @@ module Residual.Recognizers where
 
 import qualified Data.ByteString.Char8            as BSC
 import           Data.Macaw.Analysis.FunctionArgs (FunctionArgAnalysisFailure (CallAnalysisError, PLTStubNotSupported))
+import           Data.Maybe                       (fromJust)
 import           Flexdis86                        (DisassembledAddr (disInstruction),
                                                    InstructionInstanceF (iiArgs, iiOp),
                                                    JumpSize (JSize8),
@@ -37,7 +38,7 @@ classifyInstrs instrs
 
 inspectInstr :: DisassembledAddr -> (String, [Value])
 inspectInstr addr =
-  let Just i = disInstruction addr in
+  let i = fromJust $ disInstruction addr in
   (BSC.unpack $ iiOp i, fst <$> iiArgs i)
 
 isNopInstr :: DisassembledAddr -> Bool

--- a/reopt-relink/Main_relink.hs
+++ b/reopt-relink/Main_relink.hs
@@ -3,14 +3,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Main (main) where
 
 import Control.Exception
 import Control.Monad
+import Data.List (intercalate)
 import Data.Version (versionBranch)
 import qualified Data.Yaml as Yaml
 import Paths_reopt (version)
@@ -21,12 +20,12 @@ import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import System.IO
 import System.IO.Error
+import Text.Printf (printf)
 
 reoptVersion :: String
 reoptVersion = "Reopt relinker (reopt-relink) " ++ versionString ++ "."
   where
-    [h, l, r] = versionBranch version
-    versionString = show h ++ "." ++ show l ++ "." ++ show r
+    versionString = intercalate "." $ map (printf "%d") $ versionBranch version
 
 ------------------------------------------------------------------------
 -- Utilities

--- a/reopt.cabal
+++ b/reopt.cabal
@@ -19,9 +19,9 @@ library
   default-language: Haskell2010
   build-depends:
     base >= 4,
-    aeson < 2.0,
+    aeson > 2 && < 3,
     attoparsec,
-    base-encoding,
+    base64,
     bytestring,
     containers,
     directory,
@@ -31,7 +31,7 @@ library
     flexdis86 >= 0.1.1,
     galois-dwarf >= 0.2.2,
     generic-lens,
-    hashable,
+    hashable < 1.4,
     language-c >= 0.9.2,
     lens,
     llvm-pretty >= 0.11.0,

--- a/reopt/Main_reopt.hs
+++ b/reopt/Main_reopt.hs
@@ -63,9 +63,9 @@ import           Reopt.TypeInference.ConstraintGen
 import           Reopt.TypeInference.Pretty        (ppFunction)
 
 reoptVersion :: String
-reoptVersion = printf "Reopt binary reoptimizer (reopt) %d.%d.%d." h l r
+reoptVersion = printf "Reopt binary reoptimizer (reopt) %s." v
   where
-    [h, l, r] = versionBranch version
+    v = intercalate "." $ map (printf "%d") $ versionBranch version
 
 -- | Write a builder object to a file if defined or standard out if not.
 writeOutput :: Maybe FilePath -> (Handle -> IO a) -> IO a
@@ -1038,23 +1038,18 @@ main' = do
   args <- getCommandLineArgs
   setDebugKeys (args ^. debugKeys)
   case args ^. reoptAction of
-    DumpDisassembly -> do
-      dumpDisassembly args
+    DumpDisassembly -> dumpDisassembly args
     ShowCFG ->
       writeOutput (outputPath args) $ \h -> do
         hPutStrLn h =<< showCFG args
     ShowConstraints -> showConstraints args
-    ServerMode -> do
-      runServer
-    ShowHelp -> do
-      print $ helpText [] HelpFormatAll arguments
+    ServerMode -> runServer
+    ShowHelp -> print $ helpText [] HelpFormatAll arguments
     ShowHomeDirectory -> do
       homeDir <- reoptHomeDir
       print $ "Reopt's current home directory: " ++ homeDir
-    ShowVersion ->
-      putStrLn (modeHelp arguments)
-    Reopt -> do
-      performReopt args
+    ShowVersion -> putStrLn (modeHelp arguments)
+    Reopt -> performReopt args
 
 main :: IO ()
 main = main' `catch` h

--- a/src/Reopt/Analysis/Domains/DiffEquations.hs
+++ b/src/Reopt/Analysis/Domains/DiffEquations.hs
@@ -129,7 +129,7 @@ addEq x y c p = do
 addCCSet :: Ord v => v -> Map v Integer -> DiffEquations v -> DiffEquations v
 addCCSet x m0 p0 = Map.foldlWithKey f p0 m0
   where f p y d = p'
-          where Just p' = addEq x y d p
+          where p' = fromJust (addEq x y d p)
 
 {-# INLINE addCCSet #-}
 

--- a/src/Reopt/CFG/LLVM.hs
+++ b/src/Reopt/CFG/LLVM.hs
@@ -9,6 +9,7 @@ layer.
 -}
 
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -20,7 +21,6 @@ layer.
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -99,7 +99,9 @@ import qualified Data.Vector as V
 import           Data.Word
 import           GHC.Stack
 import           GHC.TypeLits
+#if __GLASGOW_HASKELL__ < 900
 import           Numeric.Natural
+#endif
 import qualified Text.LLVM as L
 import qualified Text.LLVM.PP as L (ppType)
 import qualified Text.PrettyPrint.HughesPJ as HPJ
@@ -162,8 +164,6 @@ llvmLogInfoToStrings info =
     LogInfoIntToPtr i -> "inttoptr":renderCastInfo i
     LogInfoPtrToInt i -> "ptrtoint":renderCastInfo i
   where renderCastInfo (LLVMBitCastInfo src dst) = [ HPJ.render $ L.ppType src, HPJ.render $ L.ppType dst]
-
-
 
 -- | Return a LLVM type for a integer with the given width.
 llvmITypeNat :: Natural -> L.Type

--- a/src/Reopt/CFG/StackDepth.hs
+++ b/src/Reopt/CFG/StackDepth.hs
@@ -15,10 +15,11 @@ module Reopt.CFG.StackDepth
   , stackDepthOffsetValue
   ) where
 
-import Control.Lens
+import           Control.Lens
 import           Control.Monad.Except
 import           Control.Monad.State.Strict
 import           Data.Foldable as Fold (traverse_)
+import           Data.Maybe (fromJust)
 import           Data.Int
 import           Data.List (partition)
 import           Data.Map.Strict (Map)
@@ -299,9 +300,9 @@ recoverIter finfo = do
     [] -> return ()
     root_addr : s' -> do
       blockFrontier .= s'
-      spMap <- use $ blockInitStackPointers
-      let Just init_sp = Map.lookup root_addr spMap
-      let Just reg = Map.lookup root_addr (finfo^.parsedBlocks)
+      spMap <- use blockInitStackPointers
+      let init_sp = fromJust $ Map.lookup root_addr spMap
+      let reg = fromJust $ Map.lookup root_addr (finfo^.parsedBlocks)
       analyzeStmtReferences root_addr init_sp reg
       recoverIter finfo
 


### PR DESCRIPTION
Lots of changes:

- Removed dependency on the bitrotting base-encoding, favoring base64 instead.
- Bumped to aeson 2.
- Put an upper bound on hashable since our dependencies don't work with 1.4.
- Removed many causes of warnings.