### PR TITLE
Add `--trace-constraint-origins` flag

### DIFF
--- a/src/Reopt.hs
+++ b/src/Reopt.hs
@@ -282,7 +282,9 @@ data ReoptOptions = ReoptOptions
     -- | Additional paths to search for debug versions of dynamic dependencies.
     roDynDepDebugPaths :: ![FilePath],
     -- | Trace unification in the solver
-    roTraceUnification :: !Bool
+    roTraceUnification :: !Bool,
+    -- | Trace the origin of constraints
+    roTraceConstraintOrigins :: !Bool
   }
 
 -- | Reopt options with no additional functions to explore or not explore.
@@ -295,7 +297,8 @@ defaultReoptOptions =
       roDiscoveryOptions = reoptDefaultDiscoveryOptions,
       roDynDepPaths = [],
       roDynDepDebugPaths = [],
-      roTraceUnification = False
+      roTraceUnification = False,
+      roTraceConstraintOrigins = False
     }
 
 addKnownFn ::
@@ -2468,6 +2471,7 @@ recoverX86Elf loadOpts reoptOpts hdrAnn unnamedFunPrefix hdrInfo = do
   let recMod = recoveredModule recoverX86Output
   let constraints = genModuleConstraints recMod (memory discState)
                                          (roTraceUnification reoptOpts)
+                                         (roTraceConstraintOrigins reoptOpts)
 
   pure (os, discState, recoverX86Output, constraints)
 

--- a/src/Reopt/CFG/FnRep.hs
+++ b/src/Reopt/CFG/FnRep.hs
@@ -248,6 +248,7 @@ class FoldFnValue (v :: Type -> Type)  where
 
 type FnArchConstraints arch =
      ( IsArchFn (ArchFn arch)
+     , IsArchStmt (FnArchStmt arch)
      , MemWidth (ArchAddrWidth arch)
      , HasRepr (ArchFn arch (FnValue arch)) TypeRepr
      , HasRepr (ArchReg arch) TypeRepr

--- a/tests/TyConstraintTests.hs
+++ b/tests/TyConstraintTests.hs
@@ -30,6 +30,7 @@ import Reopt.TypeInference.Solver
   , pattern FConflictTy
   , ptrAddTC, ptrSubTC, OperandClass (OCOffset), ptrTC, ptrTy')
 
+import Reopt.TypeInference.Solver.Constraints (ConstraintProvenance (..))
 import Reopt.TypeInference.Solver.RowVariables (Offset, singletonFieldMap, FieldMap, fieldMapFromList)
 import Reopt.TypeInference.Solver.Monad (withFresh)
 
@@ -55,7 +56,7 @@ tv :: SolverM TyVar
 tv = freshTyVar Nothing Nothing
 
 tvEq :: TyVar -> TyVar -> SolverM ()
-tvEq v v' = eqTC (varTy v) (varTy v')
+tvEq v v' = eqTC prov (varTy v) (varTy v')
 
 
 tvEqs :: [(TyVar, TyVar)] -> SolverM ()
@@ -73,74 +74,74 @@ frecTy = FStructTy . fieldMapFromList
 -- Simple tests having to do with equality constraints
 eqCTests :: T.TestTree
 eqCTests = T.testGroup "Equality Constraint Tests"
-  [ mkTest "Single eqTC var left"  (do { x0 <- tv; eqTC (varTy x0) num64; pure [(x0, fnum64)] })
-  , mkTest "Single eqTC var right" (do { x0 <- tv; eqTC num64 (varTy x0); pure [(x0, fnum64)] })
+  [ mkTest "Single eqTC var left"  (do { x0 <- tv; eqTC prov (varTy x0) num64; pure [(x0, fnum64)] })
+  , mkTest "Single eqTC var right" (do { x0 <- tv; eqTC prov num64 (varTy x0); pure [(x0, fnum64)] })
   , mkTest "Multiple eqTCs" $ do
       x0 <- tv
       x1 <- tv
-      eqTC (varTy x0) num64
-      eqTC (varTy x1) (ptrTy' num64)
+      eqTC prov (varTy x0) num64
+      eqTC prov (varTy x1) (ptrTy' num64)
       pure [(x0, fnum64), (x1, fptrTy' fnum64)]
 
   , mkTest "eqTC simple transitivity 1" $ do
       x0 <- tv
       x1 <- tv
       tvEq x0 x1
-      eqTC (varTy x1) num64
+      eqTC prov (varTy x1) num64
       pure [(x0, fnum64), (x1, fnum64)]
 
   ,  mkTest "eqTC simple Transitivity 2" $ do
       x0 <- tv
       x1 <- tv
-      eqTC (varTy x1) num64
+      eqTC prov (varTy x1) num64
       tvEq x0 x1
       pure [(x0, fnum64), (x1, fnum64)]
 
   , mkTest "eqTC simple transitivity 3" $ do
       x0 <- tv; x1 <- tv; x2 <- tv
       tvEqs [(x1, x2), (x0, x1)]
-      eqTC (varTy x2) num64
+      eqTC prov (varTy x2) num64
       pure [(x0, fnum64), (x1, fnum64), (x2, fnum64)]
 
   , mkTest "eqTC with pointers 1" $ do
       x0 <- tv; x1 <- tv; x2 <- tv; x3 <- tv
       tvEqs [(x1, x2), (x0, x1) ]
-      eqTC (varTy x2) num64
-      eqTC (varTy x3) (ptrTy' num64)
+      eqTC prov (varTy x2) num64
+      eqTC prov (varTy x3) (ptrTy' num64)
       pure [(x0, fnum64), (x1, fnum64), (x2, fnum64), (x3, fptrTy' fnum64)]
 
   , mkTest "eqTC with pointers 2" $ do
       x0 <- tv; x1 <- tv; x2 <- tv; x3 <- tv; x4 <- tv
       tvEqs [(x0, x2)]
-      eqTC (varTy x1) (ptrTy' (varTy x2))
-      eqTC (varTy x2) num64
-      eqTC (varTy x3) num64
-      eqTC (varTy x4) (ptrTy' (varTy x3))
+      eqTC prov (varTy x1) (ptrTy' (varTy x2))
+      eqTC prov (varTy x2) num64
+      eqTC prov (varTy x3) num64
+      eqTC prov (varTy x4) (ptrTy' (varTy x3))
 
       pure [(x0, fnum64), (x1, fptrTy' fnum64), (x2, fnum64), (x3, fnum64), (x4, fptrTy' fnum64)]
 
   , mkTest "eqTC with pointers 3" $ do
       x0 <- tv; x1 <- tv; x2 <- tv; x3 <- tv; x4 <- tv
       tvEqs [(x0, x2)]
-      eqTC (varTy x1) (ptrTy' (varTy x2))
-      eqTC (varTy x3) num64
-      eqTC (varTy x4) (ptrTy' (varTy x3))
+      eqTC prov (varTy x1) (ptrTy' (varTy x2))
+      eqTC prov (varTy x3) num64
+      eqTC prov (varTy x4) (ptrTy' (varTy x3))
 
       pure [(x0, FUnknownTy), (x1, fptrTy' FUnknownTy), (x2, FUnknownTy), (x3, fnum64), (x4, fptrTy' fnum64)]
 
   , mkTest "eqTC with records 1" $ do
       x0 <- tv; x1 <- tv; x2 <- tv; x3 <- tv
       tvEqs [ (x1, x2), (x0, x1) ]
-      eqTC (varTy x2) num64
-      eqTC (varTy x3) (ptrTy' (varTy x0))
+      eqTC prov (varTy x2) num64
+      eqTC prov (varTy x3) (ptrTy' (varTy x0))
       pure [(x0, fnum64), (x1, fnum64), (x2, fnum64), (x3, FPtrTy $ frecTy [(0, fnum64)])]
 
   , mkTest "eqTC with records 2" $ do
       x0 <- tv; x1 <- tv; x2 <- tv; x3 <- tv
       tvEqs [ (x1, x2) ]
-      eqTC (varTy x0) (ptrTy' (varTy x1))
-      eqTC (varTy x2) num64
-      eqTC (varTy x3) (ptrTy $ recTy [(0, varTy x0), (8, varTy x1)])
+      eqTC prov (varTy x0) (ptrTy' (varTy x1))
+      eqTC prov (varTy x2) num64
+      eqTC prov (varTy x3) (ptrTy $ recTy [(0, varTy x0), (8, varTy x1)])
       pure [ (x0, fptrTy' fnum64), (x1, fnum64), (x2, fnum64)
            , (x3, FPtrTy $ frecTy [(0, fptrTy' fnum64), (8, fnum64)])
            ]
@@ -158,8 +159,8 @@ eqCTests = T.testGroup "Equality Constraint Tests"
   , mkTest "eqTC with records+rows 1" $ do
       x0 <- tv
       let x0Ty = varTy x0
-      eqTC x0Ty (ptrTy $ recTy [(0, num64)])
-      eqTC x0Ty (ptrTy $ recTy [(8, ptrTy' num64)])
+      eqTC prov x0Ty (ptrTy $ recTy [(0, num64)])
+      eqTC prov x0Ty (ptrTy $ recTy [(8, ptrTy' num64)])
       pure [(x0, FPtrTy $ frecTy [(0, fnum64), (8, fptrTy' fnum64)])]
 
   -- , mkTest "eqTC with records+rows 2" $ do
@@ -208,8 +209,8 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x1Ty = varTy x1
           x2Ty = varTy x2
 
-      eqTC x1Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
-      ptrAddTC x0Ty x1Ty x2Ty (OCOffset 8)
+      eqTC prov x1Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
+      ptrAddTC prov x0Ty x1Ty x2Ty (OCOffset 8)
       pure [(x0, fptrTy' (fptrTy' fnum64))]
 
   , mkTest "Constrained by result 1" $ do
@@ -218,9 +219,9 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x1Ty = varTy x1
           x2Ty = varTy x2
 
-      eqTC x0Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
+      eqTC prov x0Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
 
-      ptrAddTC x0Ty x1Ty x2Ty (OCOffset 8)
+      ptrAddTC prov x0Ty x1Ty x2Ty (OCOffset 8)
       pure [(x1, FPtrTy $ frecTy [(8, fnum64), (16, fptrTy' fnum64)])]
   , mkTest "Constrained by result 2" $ do
       x0 <- tv; x1 <- tv; x2 <- tv
@@ -228,10 +229,10 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x1Ty = varTy x1
           x2Ty = varTy x2
 
-      eqTC x0Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
-      eqTC x1Ty (ptrTy $ recTy [(0, ptrTy' num64)])
+      eqTC prov x0Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
+      eqTC prov x1Ty (ptrTy $ recTy [(0, ptrTy' num64)])
 
-      ptrAddTC x0Ty x1Ty x2Ty (OCOffset 8)
+      ptrAddTC prov x0Ty x1Ty x2Ty (OCOffset 8)
       pure [(x1, FPtrTy $ frecTy [(0, fptrTy' fnum64), (8, fnum64), (16, fptrTy' fnum64)])]
 
   , mkTest "Accessing pointer members from a struct pointer" $ do
@@ -241,13 +242,13 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x2Ty = varTy x2
           x3Ty = varTy x3
 
-      eqTC x0Ty (ptrTy (recTy [(0, num8)]))
-      eqTC x1Ty (ptrTy (recTy [(0, num64)]))
-      eqTC x2Ty (ptrTy (recTy [(0, num32)]))
-      eqTC x3Ty (ptrTy (recTy []))
-      ptrAddTC x0Ty x3Ty num64 (OCOffset 0)
-      ptrAddTC x1Ty x3Ty num64 (OCOffset 8)
-      ptrAddTC x2Ty x3Ty num64 (OCOffset 72)
+      eqTC prov x0Ty (ptrTy (recTy [(0, num8)]))
+      eqTC prov x1Ty (ptrTy (recTy [(0, num64)]))
+      eqTC prov x2Ty (ptrTy (recTy [(0, num32)]))
+      eqTC prov x3Ty (ptrTy (recTy []))
+      ptrAddTC prov x0Ty x3Ty num64 (OCOffset 0)
+      ptrAddTC prov x1Ty x3Ty num64 (OCOffset 8)
+      ptrAddTC prov x2Ty x3Ty num64 (OCOffset 72)
       pure [ (x0, FPtrTy (frecTy [(0, fnum8), (8, fnum64), (72, fnum32)]))
            , (x1, FPtrTy (frecTy [(0, fnum64), (64, fnum32)]))
            , (x2, FPtrTy (frecTy [(0, fnum32)]))
@@ -261,13 +262,13 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x2Ty = varTy x2
 
       -- x0 = ptr (recTy {0 -> x1} (freshRow))
-      ptrTC x1Ty x0Ty
+      ptrTC prov x1Ty x0Ty
 
       -- x1 is a byte
-      eqTC x1Ty (numTy 8)
+      eqTC prov x1Ty (numTy 8)
 
-      eqTC x2Ty num64
-      ptrAddTC x0Ty x0Ty x2Ty (OCOffset 1)
+      eqTC prov x2Ty num64
+      ptrAddTC prov x0Ty x0Ty x2Ty (OCOffset 1)
       pure [] -- Liveness
 
   , mkTest "Nested Cycle test (liveness)" $ do
@@ -278,15 +279,15 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x3Ty = varTy x3
 
       -- x0 = ptr (recTy {0 -> x1} (freshRow))
-      ptrTC x1Ty x0Ty
-      ptrTC x1Ty x3Ty
+      ptrTC prov x1Ty x0Ty
+      ptrTC prov x1Ty x3Ty
 
       -- x1 is a byte
-      eqTC x1Ty (numTy 8)
+      eqTC prov x1Ty (numTy 8)
 
-      eqTC x2Ty num64
-      ptrAddTC x3Ty x0Ty x2Ty (OCOffset 1)
-      ptrAddTC x0Ty x3Ty x2Ty (OCOffset 1)
+      eqTC prov x2Ty num64
+      ptrAddTC prov x3Ty x0Ty x2Ty (OCOffset 1)
+      ptrAddTC prov x0Ty x3Ty x2Ty (OCOffset 1)
       -- If we get here, then we have succeeded, although we may want
       -- to return a value once array stride detection produces a
       -- reasonable type.
@@ -300,16 +301,16 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x3Ty = varTy x3
 
       -- x0 = ptr (recTy {0 -> x1} (freshRow))
-      ptrTC x1Ty x0Ty
-      ptrTC x1Ty x3Ty
+      ptrTC prov x1Ty x0Ty
+      ptrTC prov x1Ty x3Ty
 
       -- x1 is a byte
-      eqTC x1Ty (numTy 8)
+      eqTC prov x1Ty (numTy 8)
 
-      eqTC x2Ty num64
+      eqTC prov x2Ty num64
       -- Inverted constraint order from above
-      ptrAddTC x0Ty x3Ty x2Ty (OCOffset 1)
-      ptrAddTC x3Ty x0Ty x2Ty (OCOffset 1)
+      ptrAddTC prov x0Ty x3Ty x2Ty (OCOffset 1)
+      ptrAddTC prov x3Ty x0Ty x2Ty (OCOffset 1)
       -- If we get here, then we have succeeded, although we may want
       -- to return a value once array stride detection produces a
       -- reasonable type.
@@ -322,11 +323,11 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
           x1Ty = varTy x1
           x2Ty = varTy x2
 
-      eqTC x1Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
-      ptrSubTC x0Ty x1Ty x2Ty (OCOffset 8)
+      eqTC prov x1Ty (ptrTy $ recTy [(0, num64), (8, ptrTy' num64)])
+      ptrSubTC prov x0Ty x1Ty x2Ty (OCOffset 8)
       pure [(x0, FPtrTy $ frecTy [(8, fnum64), (16, fptrTy' fnum64)])]
   ]
-  
+
 -- t4 = do
 --       x0 <- tv; x1 <- tv; x2 <- tv; x3 <- tv
 --       let x0Ty = varTy x0
@@ -335,7 +336,7 @@ ptrCTests = T.testGroup "Pointer Arith Constraint Tests"
 --           x3Ty = varTy x3
 
 --       r0 <- freshRowVar
---       eqTC x0Ty (recTy [(0, ptrTy x0Ty)] r0)
+--       eqTC prov x0Ty (recTy [(0, ptrTy x0Ty)] r0)
 
 
 recursiveTests :: T.TestTree
@@ -343,7 +344,7 @@ recursiveTests = T.testGroup "Recursive Type Tests"
   [ mkTest "Recursive linked list" $ do
       x0 <- tv
       let x0Ty = varTy x0
-      eqTC x0Ty (ptrTy $ recTy [(0, ptrTy' x0Ty)])
+      eqTC prov x0Ty (ptrTy $ recTy [(0, ptrTy' x0Ty)])
       pure [(x0, FPtrTy $ FNamedStruct "struct.reopt.t1")]
   ]
 
@@ -351,8 +352,8 @@ conflictTests :: T.TestTree
 conflictTests = T.testGroup "Conflict Type Tests"
   [ mkTest "Simple conflict" $ withFresh $ \x0 -> do
       let x0Ty = varTy x0
-      eqTC x0Ty num64
-      eqTC x0Ty (ptrTy' num64)
+      eqTC prov x0Ty num64
+      eqTC prov x0Ty (ptrTy' num64)
       -- eqTC x0Ty (ptrTy' num64)
       -- eqTC x0Ty (ptrTy' (ptrTy' num64))
 
@@ -360,7 +361,7 @@ conflictTests = T.testGroup "Conflict Type Tests"
   ]
 
 ghciTest :: Bool -> SolverM a -> PP.Doc d
-ghciTest doTrace t = PP.pretty . runSolverM doTrace 64 $ do
+ghciTest doTrace t = PP.pretty . runSolverM doTrace False 64 $ do
   t >> unifyConstraints
 
 newtype TypeEnv = TypeEnv [(TyVar, FTy)]
@@ -373,7 +374,7 @@ instance Show TypeEnv where
 -- tyEnv = TypeEnv . sortBy (compare `on` fst)
 
 mkTest :: String -> SolverM [(TyVar, FTy)] -> T.TestTree
-mkTest name m = T.testCase name (runSolverM False 64 test)
+mkTest name m = T.testCase name (runSolverM False False 64 test)
   where
     test = do
       expected <- m
@@ -381,3 +382,6 @@ mkTest name m = T.testCase name (runSolverM False 64 test)
       let actual = [ (k, Map.findWithDefault FUnknownTy k (csTyVars res))
                    | (k, _) <- expected ]
       pure (TypeEnv actual T.@?= TypeEnv expected)
+
+prov :: ConstraintProvenance
+prov = TestingProv


### PR DESCRIPTION
This adds a `--trace-constraint-origins` flag, which can be thought of as a souped-up version of `--trace-unification` that also prints out the provenance of each constraint. For now, I have only added the necessary machinery to print constraints arising from equality constraint (`EqC`). This alone takes quite a bit of plumbing.  Some of the constraint provenance forms (e.g., `FromSubTypeC`) are not terribly descriptive, and if these prove to be not precise enough, we can always refine them later if need be.