### PR TITLE
temp fix for ansi-wl-pprint deprecation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,8 +19,10 @@ haddock-html-location: https://hackage.haskell.org/package/$pkg-$version/docs
 
 tests: true
 
+-- NOTE: This applies to the whole package: reopt and reopt-explore
 package reopt
-  ghc-options: -Wall -Werror
+  -- no-deprecations until we get rid of ansi-wl-pprint dependency in reopt-explore
+  ghc-options: -Wall -Werror -Wno-deprecations
 package reopt-tools
   ghc-options: -Wall
 package reopt-vcg-ann


### PR DESCRIPTION
cabal now fails to build reopt-explore because it uses deprecated ansi-wl-pprint.

I have made changes upstream to flexdis86 so that it uses prettyprinter instead: https://github.com/GaloisInc/flexdis86/pull/53

But in the meantime, this makes cabal be less stringent.