### PR TITLE
make reopt output more readable for humans

### DIFF
--- a/src/Reopt.hs
+++ b/src/Reopt.hs
@@ -218,6 +218,7 @@ import Data.Parameterized.Some (Some (..))
 import Data.Parameterized.TraversableF (FoldableF)
 import Data.Set qualified as Set
 import Data.String (IsString (..))
+import qualified Data.Text as T
 import Data.Vector qualified as V
 import Data.Word (Word16, Word32, Word64)
 import Flexdis86 qualified as F
@@ -616,14 +617,15 @@ checkBlockError b = do
           , Events.discErrorBlockInsnIndex = length (Macaw.pblockStmts b)
           , Events.discErrorMessage = msg
           }
-    Macaw.ClassifyFailure _ _ ->
+    Macaw.ClassifyFailure _ reasons ->
       Just $!
         Events.DiscoveryError
           { Events.discErrorTag = Events.DiscoveryClassErrorTag
           , Events.discErrorBlockAddr = a
           , Events.discErrorBlockSize = Macaw.blockSize b
           , Events.discErrorBlockInsnIndex = length (Macaw.pblockStmts b)
-          , Events.discErrorMessage = "Unclassified control flow transfer."
+          , Events.discErrorMessage = "Unclassified control flow transfer.\n"
+              <> T.intercalate "\n" (map (T.pack . ("→ " <>)) reasons)
           }
     _ -> Nothing
 

--- a/src/Reopt/Events.hs
+++ b/src/Reopt/Events.hs
@@ -348,15 +348,15 @@ printLogEvent ::
 printLogEvent event = do
   case event of
     ReoptGlobalStepStarted s ->
-      hPutStrLn stderr $ ppGlobalStep s
-    ReoptGlobalStepFinished _ _ ->
-      hPutStrLn stderr $ printf "  Complete."
+      hPutStrLn stderr $ printf "  [BEGIN] %s" (ppGlobalStep s)
+    ReoptGlobalStepFinished s _ ->
+      hPutStrLn stderr $ printf "  [ END ] %s." (ppGlobalStep s)
     ReoptGlobalStepWarning _st msg ->
-      hPutStrLn stderr $ printf "  %s" msg
+      hPutStrLn stderr $ printf "  [ WARN] %s" msg
     ReoptFunStepStarted s f ->
-      hPutStrLn stderr $ ppFunStep s ++ " " ++ ppFunId f
-    ReoptFunStepFinished{} ->
-      hPutStrLn stderr $ printf "  Complete."
+      hPutStrLn stderr $ printf "  [BEGIN] %s for function %s" (ppFunStep s) (ppFunId f)
+    ReoptFunStepFinished s f _ ->
+      hPutStrLn stderr $ printf "  [ END ] %s for function %s" (ppFunStep s) (ppFunId f)
     ReoptFunStepFailed s _ e ->
       hPutStrLn stderr $
         case s of


### PR DESCRIPTION
I'm constantly frustrated by the output of Reopt. This makes it a bit more verbose, not great, but at least gives a vague idea of what is going okay, and what is going wrong.

BEFORE:
```
Initialization
  Complete.
Searching for dynamic dependency libc.so.6's debug info...
No debug info for libc.so.6 found.
Header Processing
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Block 0x40547a: Unclassified control flow transfer.
  Incomplete.

  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
  Complete.
```

AFTER:
```
  [BEGIN] Initialization
  [ END ] Initialization.
Searching for dynamic dependency libc.so.6's debug info...
No debug info for libc.so.6 found.
  [BEGIN] Header Processing
  [ END ] Header Processing.
  [ END ] Discovering for function _init(0x402000)
  [ END ] Discovering for function _start(0x402590)
  [ END ] Discovering for function _dl_relocate_static_pie(0x4025c0)
  [ END ] Discovering for function deregister_tm_clones(0x4025d0)
  [ END ] Discovering for function register_tm_clones(0x402600)
  [ END ] Discovering for function __do_global_dtors_aux(0x402640)
  [ END ] Discovering for function frame_dummy(0x402670)
  [ END ] Discovering for function ziperr(0x402680)
  [ END ] Discovering for function freeup(0x402b20)
  [ END ] Discovering for function error(0x402e60)
  [ END ] Discovering for function zipmessage_nl(0x402e80)
  [ END ] Discovering for function zipmessage(0x403040)
  [ END ] Discovering for function zipwarn(0x403140)
  [ END ] Discovering for function encr_passwd(0x403240)
  [ END ] Discovering for function rename_split(0x4032c0)
  [ END ] Discovering for function set_filetype(0x403350)
  Block 0x40547a: Unclassified control flow transfer.
→ Branch: IP is not an mux:
let r12636 := (bv_add rbp_0 (0xfffffffffffffcb8 :: [64]))
    r12637 := read_mem r12636 (bvle8)
    r12638 := (bv_mul (0x8 :: [64]) r12637)
    r12639 := (bv_add r12638 (0x429008 :: [64]))
    r12640 := read_mem r12639 (bvle8)
 in r12640
→ no return call: Noreturn target r12640 is not a valid address.
→ Call: Call classifier failed.
→ Return: Pattern match failure in 'do' block at src/Data/Macaw/Discovery/Classifier.hs:280:5-18
→ Jump table: Absolute jump table: Upper bounds failed:
let r12636 := (bv_add rbp_0 (0xfffffffffffffcb8 :: [64]))
    r12637 := read_mem r12636 (bvle8)
 in r12637
rsp = stack_frame - 1160
rbp = stack_frame - 8
→ Jump table: Relative jump table: Unaligned IP not a mem offset: r12640
→ PLT stub: Pattern match failure in 'do' block at src/Data/Macaw/Discovery/Classifier/PLT.hs:121:5-18
→ Jump: Jump value r12640 is not a valid address.
→ Tail call: Expected stack height of 0
  Incomplete.

  [ END ] Discovering for function help(0x40bb10)
  [ END ] Discovering for function version_info(0x40bbc0)
  [ END ] Discovering for function handler(0x40be10)
  [ END ] Discovering for function finish(0x40be60)
  [ END ] Discovering for function help_extended(0x40c110)
  [ END ] Discovering for function license(0x40c170)
```