### PR TITLE
update CI and solve caching issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Cache cabal files
       uses: actions/cache@v3
       with:
-        path: ${{env.home}}/.cabal/store/ghc-${{ env.ghc }}
+        path: ${{env.home}}/.local/state/cabal/store/ghc-${{ env.ghc }}
         # Prefer previous ref
         key: build-cabal-${{ env.ghc }}-${{ github.ref }}
         # otherwise just use most recent build.
@@ -94,9 +94,9 @@ jobs:
     - name: Create archive
       run: |
         mkdir -p dist/reopt/bin
-        cp $HOME/.cabal/bin/reopt         dist/reopt/bin
-        cp $HOME/.cabal/bin/reopt-explore dist/reopt/bin
-        cp $HOME/.cabal/bin/reopt-relink  dist/reopt/bin
+        cp $HOME/.local/bin/reopt         dist/reopt/bin
+        cp $HOME/.local/bin/reopt-explore dist/reopt/bin
+        cp $HOME/.local/bin/reopt-relink  dist/reopt/bin
         cd dist
         tar cvfz reopt.tgz reopt
     - name: Make reopt

--- a/containers/dev/Dockerfile
+++ b/containers/dev/Dockerfile
@@ -10,9 +10,9 @@ ENV PATH=/opt/rh/devtoolset-8/root/bin:${PATH}
 
 # Install GHCUP
 ENV PATH=/root/.ghcup/bin:${PATH}
-ARG ghcupVer=0.1.19.0
-ARG cabalVer=3.4.0.0
-ARG ghcVer=8.10.7
+ARG ghcupVer=0.1.19.5
+ARG cabalVer=3.10.1.0
+ARG ghcVer=9.2.8
 
 RUN mkdir -p /root/.ghcup/bin
 RUN  curl -o /root/.ghcup/bin/ghcup https://downloads.haskell.org/~ghcup/${ghcupVer}/x86_64-linux-ghcup-${ghcupVer} \


### PR DESCRIPTION
For a while the CI was being annoying and taking anything from 20 minutes to 1h30 for changes that ought to take 5 minutes.

This updates CI to use recent tooling, and fixes the (still manual) caching of the cabal store.

I will try to replace this with vetted Haskell CI actions next, but at least this fixes the current annoyance.