### PR TITLE
use Doc for discovery error messages

### DIFF
--- a/reopt/Main_reopt.hs
+++ b/reopt/Main_reopt.hs
@@ -57,7 +57,6 @@ import Paths_reopt (version)
 import Prettyprinter qualified as PP
 import Prettyprinter.Render.Text qualified as PP
 import Reopt
-import Reopt.CFG.FnRep.X86 ()
 import Reopt.ELFArchInfo (getElfArchInfo)
 import Reopt.EncodeInvariants (
   encodeInvariantFailedMsg,

--- a/reopt/Main_reopt.hs
+++ b/reopt/Main_reopt.hs
@@ -727,8 +727,9 @@ showConstraints args elfPath = do
   mr <- runReoptM printLogEvent $ do
     hdrAnn <- resolveHeader (headerPath args) (clangPath args)
 
-    let funPrefix :: BSC.ByteString
-        funPrefix = unnamedFunPrefix args
+    let
+      funPrefix :: BSC.ByteString
+      funPrefix = unnamedFunPrefix args
 
     (os, initState) <- reoptX86Init (loadOptions args) rOpts origElf
     let symAddrMap = initDiscSymAddrMap initState
@@ -835,8 +836,9 @@ performReopt args elfPath = do
   mr <- runReoptM logger2 $ do
     hdrAnn <- resolveHeader (headerPath args) (clangPath args)
 
-    let funPrefix :: BSC.ByteString
-        funPrefix = unnamedFunPrefix args
+    let
+      funPrefix :: BSC.ByteString
+      funPrefix = unnamedFunPrefix args
 
     (os, initState) <- reoptX86Init (loadOptions args) rOpts origElf
     let symAddrMap = initDiscSymAddrMap initState
@@ -889,12 +891,13 @@ performReopt args elfPath = do
             (traceConstraintOrigins args)
 
     -- FIXME: move
-    let prettyDefs =
-          [ PP.pretty n PP.<+> "=" PP.<+> PP.pretty ty
-          | (n, ty) <- mcNamedTypes moduleConstraints
-          ]
-        prettyWarnings =
-          ["# Warning: " <> PP.viaShow w | w <- mcWarnings moduleConstraints]
+    let
+      prettyDefs =
+        [ PP.pretty n PP.<+> "=" PP.<+> PP.pretty ty
+        | (n, ty) <- mcNamedTypes moduleConstraints
+        ]
+      prettyWarnings =
+        ["# Warning: " <> PP.viaShow w | w <- mcWarnings moduleConstraints]
 
     case typedFnsExportPath args of
       Nothing -> pure ()
@@ -932,16 +935,17 @@ performReopt args elfPath = do
                 Right _ -> do
                   funStepFinished AnnotationGeneration fid ()
 
-            let vcgAnn :: Ann.ModuleAnnotations
-                vcgAnn =
-                  Ann.ModuleAnnotations
-                    { Ann.llvmFilePath = llvmPath
-                    , Ann.binFilePath = elfPath
-                    , Ann.pageSize = 4096
-                    , Ann.stackGuardPageCount = 1
-                    , Ann.functions = rights (snd <$> ann)
-                    , Ann.extFunctions = ext
-                    }
+            let
+              vcgAnn :: Ann.ModuleAnnotations
+              vcgAnn =
+                Ann.ModuleAnnotations
+                  { Ann.llvmFilePath = llvmPath
+                  , Ann.binFilePath = elfPath
+                  , Ann.pageSize = 4096
+                  , Ann.stackGuardPageCount = 1
+                  , Ann.functions = rights (snd <$> ann)
+                  , Ann.extFunctions = ext
+                  }
             reoptWriteByteString AnnotationsFileType annPath (Aeson.encode vcgAnn)
             funStepAllFinished AnnotationGeneration ()
 

--- a/src/Reopt/ELFArchInfo.hs
+++ b/src/Reopt/ELFArchInfo.hs
@@ -22,8 +22,8 @@ import Data.Vector qualified as V
 import Data.ByteString qualified as BS
 
 import Data.Macaw.Architecture.Info (ArchitectureInfo (..))
+import Data.Macaw.CFG qualified as Macaw
 import Data.Macaw.Utils.IncComp ( incCompLog, IncCompM)
-import Data.Macaw.Discovery qualified as Macaw
 import Reopt.PLTParser as Reopt (
   PLTInfo (..),
   extractPLTEntries,
@@ -46,6 +46,7 @@ type ProcessPLTEntries w =
 
 data SomeArchitectureInfo w where
   SomeArch ::
+    Macaw.ArchConstraints arch =>
     !(ArchitectureInfo arch) ->
     !(ProcessPLTEntries (Macaw.ArchAddrWidth arch)) ->
     SomeArchitectureInfo (Macaw.ArchAddrWidth arch)

--- a/src/Reopt/Events/Export.hs
+++ b/src/Reopt/Events/Export.hs
@@ -10,6 +10,8 @@ import Data.ByteString.Lazy qualified as BSL
 import Data.Text (Text)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import Prettyprinter qualified as PP
+import Prettyprinter.Render.Text qualified as PP
 import Reopt.Events (
   DiscoveryError (
     discErrorBlockAddr,
@@ -75,7 +77,10 @@ exportEvent h evt =
             let insn = discErrorBlockInsnIndex e
             let sz = discErrorBlockSize e
             let msg = discErrorMessage e
-            emitEvent h $ CFGError f b sz insn msg
+            emitEvent h $
+              CFGError f b sz insn $
+                PP.renderStrict $
+                  PP.layoutPretty PP.defaultLayoutOptions msg
         InvariantInference -> do
           pure ()
         AnnotationGeneration -> do


### PR DESCRIPTION
For debugging block terminator classifying failures, it helps to have much more information.  This switches from a `Text`-based error message to a `Doc`-based error message to support easier rendering of complex error descriptions, including a listing of the instructions leading to classiying failures for block terminator statements.