### PR TITLE
use `reoptPrepareForRecovery` where possible

### DIFF
--- a/reopt/Main_reopt.hs
+++ b/reopt/Main_reopt.hs
@@ -692,7 +692,13 @@ showCFG args elfPath = do
     runReoptM printLogEvent $ do
       hdrAnn <- resolveHeader (headerPath args) (clangPath args)
       (_, _, _, discState) <-
-        reoptPrepareForRecovery (loadOptions args) reoptOpts hdrAnn (unnamedFunPrefix args) hdrInfo
+        reoptPrepareForRecovery
+          (loadOptions args)
+          reoptOpts
+          hdrAnn
+          (unnamedFunPrefix args)
+          hdrInfo
+          dontIntendToRecover
       pure $ show $ Macaw.ppDiscoveryStateBlocks discState
   handleEitherWithExit mr
 
@@ -714,7 +720,7 @@ showConstraints args elfPath = do
       funPrefix = unnamedFunPrefix args
 
     (os, symAddrMap, debugTypeMap, discState) <-
-      reoptPrepareForRecovery (loadOptions args) rOpts hdrAnn funPrefix origElf
+      reoptPrepareForRecovery (loadOptions args) rOpts hdrAnn funPrefix origElf dontIntendToRecover
 
     let sysp = osPersonality os
     recoverX86Output <-
@@ -818,10 +824,13 @@ performReopt args elfPath = do
       funPrefix = unnamedFunPrefix args
 
     (os, symAddrMap, debugTypeMap, discState) <-
-      reoptPrepareForRecovery (loadOptions args) rOpts hdrAnn funPrefix origElf
-
-    when (shouldRecover args) $
-      checkNoSymbolUsesReservedPrefix funPrefix symAddrMap
+      reoptPrepareForRecovery
+        (loadOptions args)
+        rOpts
+        hdrAnn
+        funPrefix
+        origElf
+        (IntendToRecover $ shouldRecover args)
 
     case cfgExportPath args of
       Nothing -> pure ()

--- a/reopt/Main_reopt.hs
+++ b/reopt/Main_reopt.hs
@@ -692,13 +692,7 @@ showCFG args elfPath = do
     runReoptM printLogEvent $ do
       hdrAnn <- resolveHeader (headerPath args) (clangPath args)
       (_, _, _, discState) <-
-        reoptPrepareForRecovery
-          (loadOptions args)
-          reoptOpts
-          hdrAnn
-          (unnamedFunPrefix args)
-          hdrInfo
-          dontIntendToRecover
+        reoptInitialDiscovery (loadOptions args) reoptOpts hdrAnn hdrInfo
       pure $ show $ Macaw.ppDiscoveryStateBlocks discState
   handleEitherWithExit mr
 
@@ -720,7 +714,7 @@ showConstraints args elfPath = do
       funPrefix = unnamedFunPrefix args
 
     (os, symAddrMap, debugTypeMap, discState) <-
-      reoptPrepareForRecovery (loadOptions args) rOpts hdrAnn funPrefix origElf dontIntendToRecover
+      reoptInitialDiscovery (loadOptions args) rOpts hdrAnn origElf
 
     let sysp = osPersonality os
     recoverX86Output <-
@@ -824,13 +818,7 @@ performReopt args elfPath = do
       funPrefix = unnamedFunPrefix args
 
     (os, symAddrMap, debugTypeMap, discState) <-
-      reoptPrepareForRecovery
-        (loadOptions args)
-        rOpts
-        hdrAnn
-        funPrefix
-        origElf
-        (IntendToRecover $ shouldRecover args)
+      reoptInitialDiscovery (loadOptions args) rOpts hdrAnn origElf
 
     case cfgExportPath args of
       Nothing -> pure ()

--- a/src/Reopt.hs
+++ b/src/Reopt.hs
@@ -2699,8 +2699,8 @@ reoptRecoveryLoop symAddrMap rOpts funPrefix sysp debugTypeMap = go
     let unexplored = newDiscState ^. Macaw.unexploredFunctions
 
     if null unexplored
-      then traceM "NOLOOP" >> return (newDiscState, recoverX86Output, recMod, moduleConstraints)
-      else traceM "LOOP" >> go newDiscState
+      then return (newDiscState, recoverX86Output, recMod, moduleConstraints)
+      else go newDiscState
 
 newtype IntendToRecover = IntendToRecover {getIntendToRecover :: Bool}
 intendToRecover, dontIntendToRecover :: IntendToRecover


### PR DESCRIPTION
With a bit of extra refactoring, all uses of Reopt's discovery can use the same helper function, rather than re-doing very similar work in multiple places.

Also renamed the confusing `checkSymbolUnused` into something a little more explicit.