### PR TITLE
Add known function pointers to discovery frontier

### DIFF
--- a/src/Reopt/ArgResolver.hs
+++ b/src/Reopt/ArgResolver.hs
@@ -57,13 +57,15 @@ showArgResolverError (DebugResolveError msg) =
 showArgResolverError VarArgsUnsupported =
   "Do not support vararg functions."
 
+instance Show ArgResolverError where
+  show = showArgResolverError
+
 -- |  State monad for resolving arguments.
 data ArgResolverState = ARS
   { arsPrev :: [X86ArgInfo]
   -- ^ Arguments identified in reverse order.
   , arsNextGPP :: [F.Reg64]
-  -- ^ General purpose registers still
-  -- available for arguments.
+  -- ^ General purpose registers still available for arguments.
   , arsXMMCount :: !Word8
   -- ^ Number of xmm registers used so far.
   }
@@ -86,11 +88,12 @@ runArgResolver (ArgResolver m) =
 
 -- | Reserve a 64-bit register for an argument
 addGPReg64 :: Monad m => String -> ArgResolver m ()
-addGPReg64 nm = ArgResolver $ do
+addGPReg64 _nm = ArgResolver $ do
   regs <- gets arsNextGPP
   case regs of
     [] ->
-      throwError $ OutOfGPRegs nm
+      return () -- Temporarily ignoring other arguments when we run out of registers
+      -- throwError $ OutOfGPRegs nm
     (r : rest) -> do
       modify $ \s ->
         s

--- a/src/Reopt/ArgResolver.hs
+++ b/src/Reopt/ArgResolver.hs
@@ -88,12 +88,13 @@ runArgResolver (ArgResolver m) =
 
 -- | Reserve a 64-bit register for an argument
 addGPReg64 :: Monad m => String -> ArgResolver m ()
-addGPReg64 _nm = ArgResolver $ do
+addGPReg64 nm = ArgResolver $ do
   regs <- gets arsNextGPP
   case regs of
     [] ->
-      return () -- Temporarily ignoring other arguments when we run out of registers
-      -- throwError $ OutOfGPRegs nm
+      -- NOTE: This is a known limitation of current Reopt, see:
+      -- https://github.com/GaloisInc/reopt/issues/313
+      throwError $ OutOfGPRegs nm
     (r : rest) -> do
       modify $ \s ->
         s

--- a/src/Reopt/CFG/Recovery.hs
+++ b/src/Reopt/CFG/Recovery.hs
@@ -1878,10 +1878,10 @@ x86RegsFunName mem funNameMap regs = do
       BVValue _ val -> do
         let faddr = absoluteAddr (fromInteger val)
         callTarget <- tryGetCallAddr faddr
-        tryLookupFunName callTarget faddr 
+        tryLookupFunName callTarget faddr
       RelocatableValue _ faddr -> do
         callTarget <- tryGetCallAddr faddr
-        tryLookupFunName callTarget faddr 
+        tryLookupFunName callTarget faddr
       SymbolValue _ (SymbolRelocation nm _ver) -> do
         pure nm
       AssignedValue (assignRhs -> ReadMem (RelocatableValue _ memVal) _) -> do
@@ -1891,11 +1891,11 @@ x86RegsFunName mem funNameMap regs = do
               | SymbolRelocation nm _version <- relocationSym r -> do
                 pure nm
             _ -> Left $ Reason IndirectCallTarget ()
-        
+
       AssignedValue{} ->
         Left $ Reason IndirectCallTarget ()
       _ ->
-        error $ "x86CallRegs, consider: " <> show ipVal
+        error $ "Unhandled symbolic program counter pattern in x86CallRegs, consider: " <> show ipVal
 
 -- | Compute dependencies of the given a function name
 x86CallRegsFromName ::
@@ -1907,7 +1907,7 @@ x86CallRegsFromName ::
   -- | Registers when call occurs.
   RegState X86Reg (Value X86_64 ids) ->
   Either RegisterUseErrorReason (CallRegs X86_64 ids)
-x86CallRegsFromName mem nm funTypeMap regs = 
+x86CallRegsFromName mem nm funTypeMap regs =
   case funTypeMap nm of
     Just tp -> x86TranslateCallType mem nm regs tp
     Nothing -> Left $ Reason UnknownCallTargetArguments nm

--- a/src/Reopt/TypeInference/DebugTypes.hs
+++ b/src/Reopt/TypeInference/DebugTypes.hs
@@ -33,7 +33,8 @@ import Text.Printf (printf)
 import Data.Macaw.CFG (
   ArchAddrWidth,
   ArchSegmentOff,
-  MemSegmentOff, MemWidth,
+  MemSegmentOff,
+  MemWidth,
  )
 import Data.Macaw.Discovery (
   NoReturnFunStatus (MayReturnFun, NoReturnFun),
@@ -345,9 +346,6 @@ resolveSubprogramType cu annMap sub entryAddr
                   reoptTypeWarning $ printf "Type error on %s: %s" debugName (showArgResolverError e)
                   pure annMap
                 Right funType -> do
-                  -- traceM $ "addNamedFunType: " <> debugName <> " at addr " <> show entryAddr
-                  -- traceM $ "with type " <> show funType
-                  -- traceM $ "with external name " <> show externalName
                   let (m, warnings) = addNamedFunType annMap debugName externalName entryAddr (ReoptNonvarargFunType funType)
                   mapM_ reoptTypeWarning warnings
                   pure m

--- a/src/Reopt/TypeInference/DebugTypes.hs
+++ b/src/Reopt/TypeInference/DebugTypes.hs
@@ -33,7 +33,7 @@ import Text.Printf (printf)
 import Data.Macaw.CFG (
   ArchAddrWidth,
   ArchSegmentOff,
-  MemSegmentOff,
+  MemSegmentOff, MemWidth,
  )
 import Data.Macaw.Discovery (
   NoReturnFunStatus (MayReturnFun, NoReturnFun),
@@ -291,6 +291,7 @@ resolveDwarfSubprogramDebugName sub moff
 
 -- | Resolve type information from subroutine.
 resolveSubprogramType ::
+  MemWidth (ArchAddrWidth arch) =>
   -- | Compile unit for this sub program
   Dwarf.CompileUnit ->
   -- | Annotations from source file
@@ -344,6 +345,9 @@ resolveSubprogramType cu annMap sub entryAddr
                   reoptTypeWarning $ printf "Type error on %s: %s" debugName (showArgResolverError e)
                   pure annMap
                 Right funType -> do
+                  -- traceM $ "addNamedFunType: " <> debugName <> " at addr " <> show entryAddr
+                  -- traceM $ "with type " <> show funType
+                  -- traceM $ "with external name " <> show externalName
                   let (m, warnings) = addNamedFunType annMap debugName externalName entryAddr (ReoptNonvarargFunType funType)
                   mapM_ reoptTypeWarning warnings
                   pure m
@@ -359,6 +363,7 @@ type ResolveAddrFn w = BSC.ByteString -> Word64 -> Maybe (MemSegmentOff w)
 
 -- | Resolve type information from subroutine.
 resolveSubprogram ::
+  MemWidth (ArchAddrWidth arch) =>
   ResolveAddrFn (ArchAddrWidth arch) ->
   -- | Compile unit for this sub program
   Dwarf.CompileUnit ->
@@ -395,6 +400,7 @@ resolveSubprogram resolveFn cu annMap sub = do
 
 -- | Add all compile units in plugin
 resolveCompileUnits ::
+  MemWidth (ArchAddrWidth arch) =>
   ResolveAddrFn (ArchAddrWidth arch) ->
   -- | Map from function names to type info.
   FunTypeMaps (ArchAddrWidth arch) ->
@@ -420,6 +426,7 @@ resolveCompileUnits resolveFn annMap (Just (Right ctx)) = do
 -- | Populate function type information using debug information.
 resolveDebugFunTypes ::
   forall arch r.
+  MemWidth (ArchAddrWidth arch) =>
   ResolveAddrFn (ArchAddrWidth arch) ->
   FunTypeMaps (ArchAddrWidth arch) ->
   -- | Elf file for header information

--- a/src/Reopt/TypeInference/FunTypeMaps.hs
+++ b/src/Reopt/TypeInference/FunTypeMaps.hs
@@ -195,9 +195,9 @@ instance PP.Pretty ReoptFunType where
   pretty ReoptOpenFunType = "<type-of-open>"
 
 
-fnPtrs :: ReoptFunType -> [Bool]
-fnPtrs (ReoptNonvarargFunType ft) = Vector.toList $ Vector.map (isFnPtr . funArgType) (funArgs ft)
-fnPtrs _ = repeat False
+fnPtrs :: ReoptFunType -> Maybe [Bool]
+fnPtrs (ReoptNonvarargFunType ft) = Just $ Vector.toList $ Vector.map (isFnPtr . funArgType) (funArgs ft)
+fnPtrs _ = Nothing
 
 
 --------------------------------------------------------------------------------

--- a/src/Reopt/TypeInference/FunTypeMaps.hs
+++ b/src/Reopt/TypeInference/FunTypeMaps.hs
@@ -19,6 +19,7 @@ module Reopt.TypeInference.FunTypeMaps (
   funTypeMapsEmpty,
   funTypeIsDefined,
   addNamedFunType,
+  fnPtrs,
 ) where
 
 import Control.Monad (when)
@@ -35,7 +36,8 @@ import Text.Printf (printf)
 import Data.Macaw.Discovery (NoReturnFunStatus (..))
 import Data.Macaw.Memory (MemSegmentOff, MemWidth)
 
-import Reopt.TypeInference.HeaderTypes (AnnFunType)
+import Reopt.TypeInference.HeaderTypes (AnnFunType (funArgs), AnnFunArg (funArgType), isFnPtr)
+import qualified Data.Vector as Vector
 
 ------------------------------------------------------------------------
 -- QualifiedSymbolName
@@ -191,6 +193,12 @@ instance PP.Pretty ReoptFunType where
   pretty (ReoptNonvarargFunType a) = PP.pretty a
   pretty (ReoptPrintfFunType{}) = "<type-of-printf>"
   pretty ReoptOpenFunType = "<type-of-open>"
+
+
+fnPtrs :: ReoptFunType -> [Bool]
+fnPtrs (ReoptNonvarargFunType ft) = Vector.toList $ Vector.map (isFnPtr . funArgType) (funArgs ft)
+fnPtrs _ = repeat False
+
 
 --------------------------------------------------------------------------------
 -- FunTypeMaps

--- a/src/Reopt/TypeInference/FunTypeMaps.hs
+++ b/src/Reopt/TypeInference/FunTypeMaps.hs
@@ -19,7 +19,7 @@ module Reopt.TypeInference.FunTypeMaps (
   funTypeMapsEmpty,
   funTypeIsDefined,
   addNamedFunType,
-  fnPtrs,
+  isFunctionWithFunctionPointerArgs,
 ) where
 
 import Control.Monad (when)
@@ -195,9 +195,12 @@ instance PP.Pretty ReoptFunType where
   pretty ReoptOpenFunType = "<type-of-open>"
 
 
-fnPtrs :: ReoptFunType -> Maybe [Bool]
-fnPtrs (ReoptNonvarargFunType ft) = Just $ Vector.toList $ Vector.map (isFnPtr . funArgType) (funArgs ft)
-fnPtrs _ = Nothing
+-- | Returns `Just` with a positional list of which arguments are expected to be function pointers
+-- if this is a function.  Otherwise, `Nothing`.
+isFunctionWithFunctionPointerArgs :: ReoptFunType -> Maybe [Bool]
+isFunctionWithFunctionPointerArgs (ReoptNonvarargFunType ft) =
+  Just $ Vector.toList $ Vector.map (isFnPtr . funArgType) (funArgs ft)
+isFunctionWithFunctionPointerArgs _ = Nothing
 
 
 --------------------------------------------------------------------------------

--- a/src/Reopt/TypeInference/FunTypeMaps.hs
+++ b/src/Reopt/TypeInference/FunTypeMaps.hs
@@ -100,7 +100,7 @@ prettyMap = prettyMapExplicit PP.pretty PP.pretty
 instance MemWidth w => PP.Pretty (SymAddrMap w) where
   pretty sam =
     PP.vcat
-      ["Name map:"
+      [ "Name map:"
       , prettyMapExplicit (PP.pretty . UTF8.toString) (PP.pretty . Set.toList) (samNameMap sam)
       , "Address map:"
       , prettyMap (samAddrMap sam)

--- a/src/Reopt/TypeInference/HeaderTypes.hs
+++ b/src/Reopt/TypeInference/HeaderTypes.hs
@@ -8,6 +8,7 @@ module Reopt.TypeInference.HeaderTypes (
   AnnFunArg (..),
   AnnType (..),
   ppAnnType,
+  isFnPtr,
 ) where
 
 import Data.ByteString.Char8 qualified as BSC
@@ -36,6 +37,10 @@ data AnnType
     TypedefAnnType !BSC.ByteString !AnnType
   | FunPtrAnnType !AnnType ![AnnType]
   deriving (Eq, Show, Read)
+
+isFnPtr :: AnnType -> Bool
+isFnPtr FunPtrAnnType{} = True
+isFnPtr _ = False
 
 -- | Pretty print the header type for the end user.
 ppAnnType :: AnnType -> String


### PR DESCRIPTION
Given a function with known symbols (e.g. a function from `libc`), Reopt now checks if any of its arguments are expected to be function pointers. If they are, Reopt instructs Macaw to add them to the discovery frontier.

This significantly improves Reopt's performance on stripped binaries, since Reopt wasn't previously able to discover the main function and conduct any meaningful analysis on the binary. Since `main` is a function pointer argument to `libc_start_main`, Reopt now adds it to the frontier.