### PR TITLE
fix confusion between GEP base type and return type

### DIFF
--- a/src/Reopt/CFG/LLVM.hs
+++ b/src/Reopt/CFG/LLVM.hs
@@ -1167,17 +1167,21 @@ bvSubPtrPtr x y = do
 
 -- | This emits a getElementPointer in the special case where the value argument is a pointer.
 llvmGEPFromPtr ::
+  HasCallStack =>
   L.Type ->
   Int ->
   L.Typed L.Value ->
   BBLLVM arch (L.Typed L.Value)
-llvmGEPFromPtr pointeeType ofs ptrV = do
-  let pointerType = L.PtrTo pointeeType
+llvmGEPFromPtr returnType ofs ptrV = do
   let
+    pointeeType =
+      case L.typedType ptrV of
+        L.PtrTo ty -> ty
+        ty -> error $ "llvmGEPFromPtr: expecter pointer type, got: " <> show ty
     zeroV = L.Typed (L.iT 32) (L.int 0)
     ofsV = L.Typed (L.iT 32) (L.int ofs)
   -- https://llvm.org/docs/GetElementPtr.html#what-is-the-first-index-of-the-gep-instruction
-  L.Typed pointerType <$> evalInstr (L.GEP False pointeeType ptrV [zeroV, ofsV])
+  L.Typed returnType <$> evalInstr (L.GEP False pointeeType ptrV [zeroV, ofsV])
 
 -- | Truncate and log.
 llvmTrunc ::


### PR DESCRIPTION
The LLVM GEP instruction is notoriously confusing, and looks like this was yet another victim.

The base type of computation is the underlying pointee type of the pointer from which operations are being done.

The return type can be the same or something else, depending on what exactly is computed by the GEP operation.

The two were conflated here which was creating bugs.  They are now distinct, with the base type being obtained from the operand (as it is easy to do), and the return type being provided by the caller (as it is otherwise annoying to computed from the operands).